### PR TITLE
Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,45 @@
+language: python
+python:
+# This is not actually used. Because it would take an overly long time
+# to build scipy we cannot use the virtual env of travis. Instead, we
+# use miniconda.
+  - "2.7"
+
+sudo: false
+
+install:
+  # Install miniconda
+  # -----------------
+  - if [[ "$TRAVIS_PYTHON_VERSION" == 2* ]]; then
+      wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    fi
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+
+  # Create the basic testing environment
+  # ------------------------------------
+  - conda config --set always_yes yes --set changeps1 no --set show_channel_urls yes
+  - conda update conda
+  - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION
+  - source activate test-environment
+
+  # Customise the testing environment
+  # ---------------------------------
+  - conda install pbr nose pip
+  - sed '/click\|dominate\|regex/d' requirements.txt | xargs conda install
+  # Conda does not package everything, so we install a couple others via pip.
+  - pip install -r requirements.txt
+
+  # Package debug
+  # -------------
+  - conda list
+  - pip freeze
+
+  # Install kraken
+  # --------------
+  - python setup.py install
+
+script:
+  - python setup.py nosetests

--- a/README
+++ b/README
@@ -2,6 +2,8 @@
  │ Description                │
  └────────────────────────────┘
 
+[![Build Status](https://travis-ci.org/mittagessen/kraken.svg)](https://travis-ci.org/mittagessen/kraken)
+
 kraken is a fork of ocropus intended to rectify a number of issues while
 preserving (mostly) functional equivalence. Its main goals are:
 


### PR DESCRIPTION
A very simple setup for testing via Travis. It uses Miniconda to install dependencies and then runs the tests with nose. With ocropy, I originally tried a straight install, but compiling SciPy took so long, it ran out of build time. The conda install is much much quicker, so I just went with that directly here.

You will of course have to enable Travis for your repo before this has a real effect.