### PR TITLE
Temporarily install Cython on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ install:
   # Customise the testing environment
   # ---------------------------------
   - conda install pbr nose pip
+  # h5py has a false dependency on Cython, so we install it until it's fixed.
+  - conda install cython
   - sed '/click\|dominate\|regex/d' requirements.txt | xargs conda install
   # Conda does not package everything, so we install a couple others via pip.
   - pip install -r requirements.txt


### PR DESCRIPTION
h5py has a false dependency on it, so it's quicker to install the pre-compiled version from conda than let pip do it. (It's 2 or 3 times longer with cython built-from-source.)

Hopefully, when https://github.com/h5py/h5py/issues/577 is fixed, this install can be dropped.