### PR TITLE
Reduce requirements a little.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ dominate==2.1.12
 numpy==1.9.2
 Pillow==2.8.1
 regex==2015.3.18
-scipy==0.15.1
-h5py==2.5.0
+scipy==0.14.0
+h5py==2.4.0


### PR DESCRIPTION
Because these are the ones currently available on Fedora 22...

I couldn't find anything in the changelogs that would indicate these versions would be a problem.