### PR TITLE
Fix output of segmenter.

### DIFF
--- a/kraken/kraken.py
+++ b/kraken/kraken.py
@@ -64,7 +64,7 @@ def segmenter(scale, black_colseps, base_image, input, output):
         raise
     with open_file(output, 'w') as fp:
         for box in res:
-            fp.write(u'{},{},{},{}\n'.format(*box).encode('utf-8'))
+            fp.write(u'{},{},{},{}\n'.format(*box))
     click.secho(u'\u2713', fg='green')
 
 


### PR DESCRIPTION
The file is opened in text mode, but writing is attempted with an encoded bytestring. Since these are just lists of numbers, the encoding doesn't really matter, so there's no need to be explicit.