### PR TITLE
Requirement updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
   # Customise the testing environment
   # ---------------------------------
   - conda install pbr nose pip
-  - sed '/click\|python-bidi\|regex\|protobuf/d' requirements.txt | xargs conda install
+  - sed '/python-bidi\|regex/d' requirements.txt | xargs conda install
   # Conda does not package everything, so we install a couple others via pip.
   - pip install -r requirements.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ python:
 # to build scipy we cannot use the virtual env of travis. Instead, we
 # use miniconda.
   - 2.7
-  - 3.3
   - 3.4
+  - 3.5
 
 notifications:
   email: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ numpy
 Pillow
 regex
 scipy
-protobuf==3.0.0b2
+protobuf>=3.0.0
 jinja2
 python-bidi


### PR DESCRIPTION
Protobuf 3 now has a final release, so there's no need to install just the beta. Also, a few packages are now available over conda and can be installed that way now.