### PR TITLE
Exception handling for binarization in ketos

### DIFF
--- a/kraken/ketos.py
+++ b/kraken/ketos.py
@@ -40,6 +40,7 @@ from kraken import binarization
 from kraken.lib import models
 from kraken.train import GroundTruthContainer, compute_error
 from kraken.lib.exceptions import KrakenCairoSurfaceException
+from kraken.lib.exceptions import KrakenInputException
 
 APP_NAME = 'kraken'
           
@@ -416,7 +417,11 @@ def line_generator(ctx, font, maxlines, encoding, normalization, renormalize,
         elif legacy:
             im = linegen.ocropy_degrade(im)
         if binarize:
-            im = binarization.nlbin(im)
+            try:
+                im = binarization.nlbin(im)
+            except KrakenInputException as e:
+                click.echo('{}'.format(e.message))
+                continue
         im.save('{}/{:06d}.png'.format(output, idx))
         with open('{}/{:06d}.gt.txt'.format(output, idx), 'wb') as fp:
             fp.write(line.encode('utf-8'))


### PR DESCRIPTION
In kraken/binarization.py:nlbin, an exception is thrown which is not handled in ketos.py. Simple try-catch statement added.