### PR TITLE
Add MANIFEST.in file for copying jinja2 templates

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include kraken/templates *


### PR DESCRIPTION
Without this, if you run e.g. `pip3 install .`, `kraken/templates`
won't get included in the install path, and e.g. `ketos transcribe`
will fail due to the missing templates.