### PR TITLE
Fix type hints for PIL.Image.Image.

### DIFF
--- a/kraken/binarization.py
+++ b/kraken/binarization.py
@@ -35,7 +35,7 @@ __all__ = ['nlbin']
 logger = logging.getLogger(__name__)
 
 
-def nlbin(im: Image,
+def nlbin(im: Image.Image,
           threshold: float = 0.5,
           zoom: float = 0.5,
           escale: float = 1.0,
@@ -48,7 +48,7 @@ def nlbin(im: Image,
     Performs binarization using non-linear processing.
 
     Args:
-        im (PIL.Image):
+        im (PIL.Image.Image):
         threshold (float):
         zoom (float): Zoom for background page estimation
         escale (float): Scale for estimating a mask over the text region

--- a/kraken/lib/dataset.py
+++ b/kraken/lib/dataset.py
@@ -311,12 +311,12 @@ class GroundTruthDataset(Dataset):
         self._gt.append(gt)
         self.alphabet.update(gt)
 
-    def add_loaded(self, image: Image, gt: str) -> None:
+    def add_loaded(self, image: Image.Image, gt: str) -> None:
         """
         Adds an already loaded  line-image-text pair to the dataset.
 
         Args:
-            image (PIL.Image): Line image
+            image (PIL.Image.Image): Line image
             gt (str): Text contained in the line image
         """
         if self.preload:

--- a/kraken/lib/lineest.py
+++ b/kraken/lib/lineest.py
@@ -1,5 +1,5 @@
 import warnings
-import PIL
+from PIL import Image
 import numpy as np
 
 from kraken.lib.util import pil2array, array2pil
@@ -65,7 +65,7 @@ class CenterNormalizer(object):
         return scaled
 
 
-def dewarp(normalizer: CenterNormalizer, im: PIL.Image) -> PIL.Image:
+def dewarp(normalizer: CenterNormalizer, im: Image.Image) -> Image.Image:
     """
     Dewarps an image of a line using a kraken.lib.lineest.CenterNormalizer
     instance.
@@ -73,7 +73,7 @@ def dewarp(normalizer: CenterNormalizer, im: PIL.Image) -> PIL.Image:
     Args:
         normalizer (kraken.lib.lineest.CenterNormalizer): A line normalizer
                                                           instance
-        im (PIL.Image): Image to dewarp
+        im (PIL.Image.Image): Image to dewarp
 
     Returns:
         PIL.Image containing the dewarped image.

--- a/kraken/lib/util.py
+++ b/kraken/lib/util.py
@@ -10,7 +10,7 @@ from PIL import Image
 __all__ = ['pil2array', 'array2pil']
 
 
-def pil2array(im: Image, alpha: int = 0) -> np.array:
+def pil2array(im: Image.Image, alpha: int = 0) -> np.array:
     if im.mode == '1':
         return np.array(im.convert('L'))
     return np.array(im)
@@ -32,12 +32,12 @@ def array2pil(a: np.array) -> Image:
         raise Exception("unknown image type")
 
 
-def is_bitonal(im: Image) -> bool:
+def is_bitonal(im: Image.Image) -> bool:
     """
     Tests a PIL.Image for bitonality.
 
     Args:
-        im (PIL.Image): Image to test
+        im (PIL.Image.Image): Image to test
 
     Returns:
         True if the image contains only two different color values. False
@@ -46,7 +46,7 @@ def is_bitonal(im: Image) -> bool:
     return im.getcolors(2) is not None and len(im.getcolors(2)) == 2
 
 
-def get_im_str(im: Image) -> str:
+def get_im_str(im: Image.Image) -> str:
     return im.filename if hasattr(im, 'filename') else str(im)
 
 

--- a/kraken/rpred.py
+++ b/kraken/rpred.py
@@ -115,13 +115,13 @@ def bidi_record(record: ocr_record) -> ocr_record:
     return ocr_record(prediction, cuts, confidences)
 
 
-def extract_boxes(im: Image, bounds: Dict[str, Any]) -> Image:
+def extract_boxes(im: Image.Image, bounds: Dict[str, Any]) -> Image:
     """
     Yields the subimages of image im defined in the list of bounding boxes in
     bounds preserving order.
 
     Args:
-        im (PIL.Image): Input image
+        im (PIL.Image.Image): Input image
         bounds (list): A list of tuples (x1, y1, x2, y2)
 
     Yields:
@@ -142,7 +142,7 @@ def extract_boxes(im: Image, bounds: Dict[str, Any]) -> Image:
 
 
 def mm_rpred(nets: Dict[str, TorchSeqRecognizer],
-             im: Image,
+             im: Image.Image,
              bounds: dict,
              pad: int = 16,
              bidi_reordering: bool = True,
@@ -157,7 +157,7 @@ def mm_rpred(nets: Dict[str, TorchSeqRecognizer],
     Args:
         nets (dict): A dict mapping ISO15924 identifiers to TorchSegRecognizer
                      objects. Recommended to be an defaultdict.
-        im (PIL.Image): Image to extract text from
+        im (PIL.Image.Image): Image to extract text from
         bounds (dict): A dictionary containing a 'boxes' entry
                         with a list of lists of coordinates (script, (x0, y0,
                         x1, y1)) of a text line in the image and an entry
@@ -250,7 +250,7 @@ def mm_rpred(nets: Dict[str, TorchSeqRecognizer],
 
 
 def rpred(network: TorchSeqRecognizer,
-          im: Image,
+          im: Image.Image,
           bounds: dict,
           pad: int = 16,
           bidi_reordering: bool = True) -> Generator[ocr_record, None, None]:
@@ -260,7 +260,7 @@ def rpred(network: TorchSeqRecognizer,
     Args:
         network (kraken.lib.models.TorchSeqRecognizer): A TorchSegRecognizer
                                                         object
-        im (PIL.Image): Image to extract text from
+        im (PIL.Image.Image): Image to extract text from
         bounds (dict): A dictionary containing a 'boxes' entry with a list of
                        coordinates (x0, y0, x1, y1) of a text line in the image
                        and an entry 'text_direction' containing


### PR DESCRIPTION
The type hints for functions that take a PIL Image as input where using the Image submodule and not the Image.Image class.