### PR TITLE
Fix "NameError: name 'collate_sequences' is not defined" error during training.

### DIFF
--- a/kraken/lib/train.py
+++ b/kraken/lib/train.py
@@ -31,7 +31,7 @@ from typing import cast, Tuple, Callable, List, Dict, Any, Optional, Sequence
 from kraken.lib import models, vgsl, segmentation, default_specs
 from kraken.lib.util import make_printable
 from kraken.lib.codec import PytorchCodec
-from kraken.lib.dataset import BaselineSet, GroundTruthDataset, PolygonGTDataset, generate_input_transforms, preparse_xml_data, InfiniteDataLoader, compute_error
+from kraken.lib.dataset import BaselineSet, GroundTruthDataset, PolygonGTDataset, generate_input_transforms, preparse_xml_data, InfiniteDataLoader, compute_error, collate_sequences
 from kraken.lib.exceptions import KrakenInputException, KrakenEncodeException
 
 from torch.utils.data import DataLoader


### PR DESCRIPTION
one import was missing.