### PR TITLE
Fixes to region training when using BaselineSet.add().

### DIFF
--- a/kraken/lib/dataset.py
+++ b/kraken/lib/dataset.py
@@ -862,24 +862,24 @@ class BaselineSet(Dataset):
         """
         if self.mode:
             raise Exception('The `add` method is incompatible with dataset mode {}'.format(self.mode))
-
-        lines = defaultdict(list)
+        baselines_ = defaultdict(list)
         for line in baselines:
             line_type = self.mbl_dict.get(line['script'], line['script'])
             if self.valid_baselines is None or line['script'] in self.valid_baselines:
-                lines[line_type].append(line['baseline'])
+                baselines_[line_type].append(line['baseline'])
                 if line_type not in self.class_mapping['baselines']:
                     self.num_classes += 1
                     self.class_mapping['baselines'][line_type] = self.num_classes - 1
-        regions = defaultdict(list)
+        regions_ = defaultdict(list)
         for k, v in regions.items():
-            if self.valid_regions is None or k in self.valid_regions:
-                reg_type = self.mreg_dict.get(k, k)
-                regions[reg_type].extend(v)
+            reg_type = self.mreg_dict.get(k, k)
+            if self.valid_regions is None or reg_type in self.valid_regions:
+                regions_[reg_type].extend(v)
                 if reg_type not in self.class_mapping['regions']:
                     self.num_classes += 1
-                    self.class_mapping['baselines'][line_type] = self.num_classes - 1
-        self.targets.append({'baselines': lines, 'regions': regions})
+                    self.class_mapping['regions'][reg_type] = self.num_classes - 1
+        self.targets.append({'baselines': baselines_, 'regions': regions_})
+
         self.imgs.append(image)
 
     def __getitem__(self, idx):
@@ -958,4 +958,3 @@ class BaselineSet(Dataset):
 
     def __len__(self):
         return len(self.imgs)
-


### PR DESCRIPTION
This fixes 
* the overriding of the `regions` variable.
* a merged region type not being valid.
* the region type being put in the baselines class mapping.

But it  raises:
```
UserWarning: Using a target size (torch.Size([1, 4, 1200, 876])) that is different to the input size (torch.Size([1, 3, 1200, 876])) is deprecated. Please ensure they have the same size.
  return F.binary_cross_entropy(input, target, weight=self.weight, reduction=self.reduction)
```

And ultimately  

```raised unexpected: ValueError('Target and input must have the same number of elements. target nelement (4204800) != input nelement (3153600)')
Traceback (most recent call last):
  File "/home/robin/Projects/escriptorium/env/lib/python3.7/site-packages/celery/app/trace.py", line 385, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/home/robin/Projects/escriptorium/env/lib/python3.7/site-packages/celery/app/trace.py", line 650, in __protected_call__
    return self.run(*args, **kwargs)
  File "/home/robin/Projects/escriptorium/env/lib/python3.7/site-packages/celery/app/base.py", line 474, in run
    return task._orig_run(*args, **kwargs)
  File "/home/robin/Projects/escriptorium/app/apps/core/tasks.py", line 225, in segtrain
    raise e
  File "/home/robin/Projects/escriptorium/app/apps/core/tasks.py", line 212, in segtrain
    trainer.run(_print_eval)
  File "/home/robin/Projects/escriptorium/env/lib/python3.7/site-packages/kraken/lib/train.py", line 376, in run
    loss = self.loss_fn(self.model.criterion, o, target)
  File "/home/robin/Projects/escriptorium/env/lib/python3.7/site-packages/kraken/lib/train.py", line 261, in baseline_label_loss_fn
    loss = criterion(output, target)
  File "/home/robin/Projects/escriptorium/env/lib/python3.7/site-packages/torch/nn/modules/module.py", line 550, in __call__
    result = self.forward(*input, **kwargs)
  File "/home/robin/Projects/escriptorium/env/lib/python3.7/site-packages/torch/nn/modules/loss.py", line 516, in forward
    return F.binary_cross_entropy(input, target, weight=self.weight, reduction=self.reduction)
  File "/home/robin/Projects/escriptorium/env/lib/python3.7/site-packages/torch/nn/functional.py", line 2372, in binary_cross_entropy
    "!= input nelement ({})".format(target.numel(), input.numel()))
ValueError: Target and input must have the same number of elements. target nelement (4204800) != input nelement (3153600)
```
