### PR TITLE
Reset the epoch count when training on top of a model.

### DIFF
--- a/kraken/lib/train.py
+++ b/kraken/lib/train.py
@@ -827,14 +827,16 @@ class KrakenTrainer(object):
             message(f'Loading existing model from {load} ', nl=False)
             nn = vgsl.TorchVGSLModel.load_model(load)
             if load_hyper_parameters:
-                hyper_params_.update(nn.hyper_params)
-                if (hyper_params_['quit'] == 'dumb' and
-                    hyper_params_['epochs'] >= hyper_params_['completed_epochs']):
-                    logger.warning(f'Using maximum epochs from loaded model, starting again from 0.')
-                    hyper_params_['epochs'] = 0
+                if hyper_params:
+                    hyper_params_.update(nn.hyper_params)
             message('\u2713', fg='green', nl=False)
 
         hyper_params_.update(hyper_params)
+        if (hyper_params_['quit'] == 'dumb' and
+            hyper_params_['epochs'] >= hyper_params_['completed_epochs']):
+            logger.warning('Maximum epochs reached (might be loaded from given model), starting again from 0.')
+            hyper_params_['epochs'] = 0
+
         hyper_params = hyper_params_
 
         # preparse input sizes from vgsl string to seed ground truth data set

--- a/kraken/lib/train.py
+++ b/kraken/lib/train.py
@@ -830,8 +830,8 @@ class KrakenTrainer(object):
                 if hyper_params:
                     hyper_params_.update(nn.hyper_params)
             message('\u2713', fg='green', nl=False)
-
-        hyper_params_.update(hyper_params)
+        if hyper_params:
+            hyper_params_.update(hyper_params)
         if (hyper_params_['quit'] == 'dumb' and
             hyper_params_['epochs'] >= hyper_params_['completed_epochs']):
             logger.warning('Maximum epochs reached (might be loaded from given model), starting again from 0.')


### PR DESCRIPTION
Fixes the issue of loading a model, and using its hyper parameters without explicitly setting the count to 0.
It feels a bit weird because restarting a training and training a new model on top of another one goes through the same code/checks?

I changed the hyper_params argument to default to None which allows to only set relevant params in the calling code. So you can just do `hyper_params={'quit': 'early'}` for example instead of loading `kraken.default_specs.SEGMENTATION_HYPER_PARAMS` and overriding what you need. The given params now also supersedes the model's so you can overwrite them.
defaults < model's < user's

I also moved `nn.hyper_params = hyper_params` lower so that it gets applied to just created models as well.

I wanted an early check but if it's correct then I will apply the same logic to recognition_train_gen.