### PR TITLE
Fix spacing in help message for CLI options

### DIFF
--- a/kraken/contrib/extract_lines.py
+++ b/kraken/contrib/extract_lines.py
@@ -4,19 +4,19 @@ import click
 
 @click.command()
 @click.option('-f', '--format-type', type=click.Choice(['xml', 'alto', 'page']), default='xml',
-              help='Sets the input document format. In ALTO and PageXML mode all'
-              'data is extracted from xml files containing both baselines, polygons, and a'
+              help='Sets the input document format. In ALTO and PageXML mode all '
+              'data is extracted from xml files containing both baselines, polygons, and a '
               'link to source images.')
 @click.option('-i', '--model', default=None, show_default=True, type=click.Path(exists=True),
               help='Baseline detection model to use. Overrides format type and expects image files as input.')
 @click.option('--repolygonize/--no-repolygonize', show_default=True,
-              default=False, help='Repolygonizes line data in ALTO/PageXML'
-              'files. This ensures that the trained model is compatible with the'
-              'segmenter in kraken even if the original image files either do'
-              'not contain anything but transcriptions and baseline information'
-              'or the polygon data was created using a different method. Will'
-              'be ignored in `path` mode. Note, that this option will be slow'
-              'and will not scale input images to the same size as the segmenter'
+              default=False, help='Repolygonizes line data in ALTO/PageXML '
+              'files. This ensures that the trained model is compatible with the '
+              'segmenter in kraken even if the original image files either do '
+              'not contain anything but transcriptions and baseline information '
+              'or the polygon data was created using a different method. Will '
+              'be ignored in `path` mode. Note, that this option will be slow '
+              'and will not scale input images to the same size as the segmenter '
               'does.')
 @click.argument('files', nargs=-1)
 def cli(format_type, model, repolygonize, files):

--- a/kraken/contrib/forced_alignment_overlay.py
+++ b/kraken/contrib/forced_alignment_overlay.py
@@ -34,14 +34,14 @@ def slugify(value):
 
 @click.command()
 @click.option('-f', '--format-type', type=click.Choice(['xml', 'alto', 'page']), default='xml',
-              help='Sets the input document format. In ALTO and PageXML mode all'
-              'data is extracted from xml files containing both baselines, polygons, and a'
+              help='Sets the input document format. In ALTO and PageXML mode all '
+              'data is extracted from xml files containing both baselines, polygons, and a '
               'link to source images.')
 @click.option('-i', '--model', default=None, show_default=True, type=click.Path(exists=True),
               help='Transcription model to use.')
 @click.option('-o', '--output', type=click.Choice(['alto', 'pagexml', 'overlay']),
-              show_default=True, default='overlay', help='Output mode. Either page or'
-              ' alto for xml output, overlay for image overlays.')
+              show_default=True, default='overlay', help='Output mode. Either page or '
+              'alto for xml output, overlay for image overlays.')
 @click.argument('files', nargs=-1)
 def cli(format_type, model, output, files):
     """

--- a/kraken/contrib/repolygonize.py
+++ b/kraken/contrib/repolygonize.py
@@ -8,8 +8,8 @@ import click
 
 @click.command()
 @click.option('-f', '--format-type', type=click.Choice(['alto', 'page']), default='alto',
-              help='Sets the input document format. In ALTO and PageXML mode all'
-              'data is extracted from xml files containing both baselines, polygons, and a'
+              help='Sets the input document format. In ALTO and PageXML mode all '
+              'data is extracted from xml files containing both baselines, polygons, and a '
               'link to source images.')
 @click.argument('files', nargs=-1)
 def cli(format_type, files):

--- a/kraken/contrib/segmentation_overlay.py
+++ b/kraken/contrib/segmentation_overlay.py
@@ -30,19 +30,19 @@ def slugify(value):
 
 @click.command()
 @click.option('-f', '--format-type', type=click.Choice(['xml', 'alto', 'page']), default='xml',
-              help='Sets the input document format. In ALTO and PageXML mode all'
-              'data is extracted from xml files containing both baselines, polygons, and a'
+              help='Sets the input document format. In ALTO and PageXML mode all '
+              'data is extracted from xml files containing both baselines, polygons, and a '
               'link to source images.')
 @click.option('-i', '--model', default=None, show_default=True, type=click.Path(exists=True),
               help='Baseline detection model to use. Overrides format type and expects image files as input.')
 @click.option('--repolygonize/--no-repolygonize', show_default=True,
-              default=False, help='Repolygonizes line data in ALTO/PageXML'
-              'files. This ensures that the trained model is compatible with the'
-              'segmenter in kraken even if the original image files either do'
-              'not contain anything but transcriptions and baseline information'
-              'or the polygon data was created using a different method. Will'
-              'be ignored in `path` mode. Note, that this option will be slow'
-              'and will not scale input images to the same size as the segmenter'
+              default=False, help='Repolygonizes line data in ALTO/PageXML '
+              'files. This ensures that the trained model is compatible with the '
+              'segmenter in kraken even if the original image files either do '
+              'not contain anything but transcriptions and baseline information '
+              'or the polygon data was created using a different method. Will '
+              'be ignored in `path` mode. Note, that this option will be slow '
+              'and will not scale input images to the same size as the segmenter '
               'does.')
 @click.argument('files', nargs=-1)
 def cli(format_type, model, repolygonize, files):

--- a/kraken/ketos.py
+++ b/kraken/ketos.py
@@ -133,14 +133,14 @@ def _validate_merging(ctx, param, value):
 @click.option('--load-hyper-parameters/--no-load-hyper-parameters', show_default=True, default=False,
               help='When loading an existing model, retrieve hyper-parameters from the model')
 @click.option('--force-binarization/--no-binarization', show_default=True,
-              default=False, help='Forces input images to be binary, otherwise'
-              'the appropriate color format will be auto-determined through the'
+              default=False, help='Forces input images to be binary, otherwise '
+              'the appropriate color format will be auto-determined through the '
               'network specification. Will be ignored in `path` mode.')
 @click.option('-f', '--format-type', type=click.Choice(['path', 'xml', 'alto', 'page']), default='xml',
-              help='Sets the training data format. In ALTO and PageXML mode all'
-              'data is extracted from xml files containing both baselines and a'
-              'link to source images. In `path` mode arguments are image files'
-              'sharing a prefix up to the last extension with JSON `.path` files'
+              help='Sets the training data format. In ALTO and PageXML mode all '
+              'data is extracted from xml files containing both baselines and a '
+              'link to source images. In `path` mode arguments are image files '
+              'sharing a prefix up to the last extension with JSON `.path` files '
               'containing the baseline information.')
 @click.option('--suppress-regions/--no-suppress-regions', show_default=True, default=False, help='Disables region segmentation training.')
 @click.option('--suppress-baselines/--no-suppress-baselines', show_default=True, default=False, help='Disables baseline segmentation training.')
@@ -506,23 +506,23 @@ def train(ctx, batch_size, pad, output, spec, append, load, freq, quit, epochs,
 @click.option('-n', '--normalize-whitespace/--no-normalize-whitespace',
               show_default=True, default=True, help='Normalizes unicode whitespace')
 @click.option('--repolygonize/--no-repolygonize', show_default=True,
-              default=False, help='Repolygonizes line data in ALTO/PageXML'
-              'files. This ensures that the trained model is compatible with the'
-              'segmenter in kraken even if the original image files either do'
-              'not contain anything but transcriptions and baseline information'
-              'or the polygon data was created using a different method. Will'
-              'be ignored in `path` mode. Note, that this option will be slow'
-              'and will not scale input images to the same size as the segmenter'
+              default=False, help='Repolygonizes line data in ALTO/PageXML '
+              'files. This ensures that the trained model is compatible with the '
+              'segmenter in kraken even if the original image files either do '
+              'not contain anything but transcriptions and baseline information '
+              'or the polygon data was created using a different method. Will '
+              'be ignored in `path` mode. Note, that this option will be slow '
+              'and will not scale input images to the same size as the segmenter '
               'does.')
 @click.option('--force-binarization/--no-binarization', show_default=True,
-              default=False, help='Forces input images to be binary, otherwise'
-              'the appropriate color format will be auto-determined through the'
+              default=False, help='Forces input images to be binary, otherwise '
+              'the appropriate color format will be auto-determined through the '
               'network specification. Will be ignored in `path` mode.')
 @click.option('-f', '--format-type', type=click.Choice(['path', 'xml', 'alto', 'page']), default='path',
-              help='Sets the training data format. In ALTO and PageXML mode all'
-              'data is extracted from xml files containing both baselines and a'
-              'link to source images. In `path` mode arguments are image files'
-              'sharing a prefix up to the last extension with JSON `.path` files'
+              help='Sets the training data format. In ALTO and PageXML mode all '
+              'data is extracted from xml files containing both baselines and a '
+              'link to source images. In `path` mode arguments are image files '
+              'sharing a prefix up to the last extension with JSON `.path` files '
               'containing the baseline information.')
 @click.argument('test_set', nargs=-1, callback=_expand_gt, type=click.Path(exists=False, dir_okay=False))
 def test(ctx, batch_size, model, evaluation_files, device, pad, threads,

--- a/kraken/kraken.py
+++ b/kraken/kraken.py
@@ -271,8 +271,8 @@ def recognizer(model, pad, no_segmentation, bidi_reordering, script_ignore, inpu
                    'are `src` (source file), `idx` (page number), and `uuid` (v4 uuid). '
                    '`-o` suffixes are appended to this format string.')
 @click.option('-h', '--hocr', 'serializer',
-              help='Switch between hOCR, ALTO, abbyyXML, PageXML or "native"'
-              'output. Native are plain image files for image, JSON for'
+              help='Switch between hOCR, ALTO, abbyyXML, PageXML or "native" '
+              'output. Native are plain image files for image, JSON for '
               'segmentation, and text for transcription output.',
               flag_value='hocr')
 @click.option('-a', '--alto', 'serializer', flag_value='alto')


### PR DESCRIPTION
In the help text of some CLI options, some spaces were missing because help messages were split over multiple string segments.
This PR adds the missing spaces.