### PR TITLE
Add reading order tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install wheel pbr flake8 pytest nose hocr-spec
-          # if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           python setup.py install
       - name: Lint with flake8
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,11 +16,12 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
+      - name: Install dependencies and kraken
         run: |
           python -m pip install --upgrade pip
           pip install flake8 pytest nose hocr-spec
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install .
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,4 +30,4 @@ jobs:
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Test
         run: |
-          pytest
+          pytest -k 'not test_train'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest
+          pip install flake8 pytest nose hocr-spec
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Lint with flake8
         run: |
@@ -29,4 +29,4 @@ jobs:
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Test
         run: |
-          python setup.py test
+          pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,9 +19,9 @@ jobs:
       - name: Install dependencies and kraken
         run: |
           python -m pip install --upgrade pip
-          pip install wheel flake8 pytest nose hocr-spec
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          pip install .
+          pip install wheel pbr flake8 pytest nose hocr-spec
+          # if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          python setup.py install
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,9 @@
-name: Python package
+name: Lint and test
 
 on: [push]
 
 jobs:
-  build:
+  lint_and_test:
 
     runs-on: ubuntu-latest
     strategy:
@@ -28,6 +28,6 @@ jobs:
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      - name: Test
+      - name: Run tests, except training tests
         run: |
           pytest -k 'not test_train'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install dependencies and kraken
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest nose hocr-spec
+          pip install wheel flake8 pytest nose hocr-spec
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           pip install .
       - name: Lint with flake8

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 Description
 ===========
 
-.. image:: https://travis-ci.org/mittagessen/kraken.svg?branch=master
-    :target: https://travis-ci.org/mittagessen/kraken
+.. image:: https://github.com/mittagessen/kraken/actions/workflows/test.yml/badge.svg
+    :target: https://github.com/mittagessen/kraken/actions/workflows/test.yml
 
 kraken is a turn-key OCR system optimized for historical and non-Latin script
 material.

--- a/kraken/align.py
+++ b/kraken/align.py
@@ -39,7 +39,7 @@ try:
     import pywrapfst as fst
 
     _get_fst = lambda: fst.VectorFst()
-    _get_best_weight = lambda x: fst.Weight.one(f.weight_type())
+    _get_best_weight = lambda x: fst.Weight.one(fst.weight_type())
 except ImportError:
     logger.info('pywrapfst not available. Falling back to openfst_python.')
     try:

--- a/kraken/contrib/print_word_spreader.py
+++ b/kraken/contrib/print_word_spreader.py
@@ -196,7 +196,7 @@ def rewrite_ocr_page_title(xhtml, file_name, image_x, image_y):
     return xhtml
 
 if not(os.path.isdir(args.inputDir)):
-    print('Input directory "'+image_dir+'" does not exist.\n\tExiting ...')
+    print('Input directory "'+args.inputDir+'" does not exist.\n\tExiting ...')
     sys.exit(1)
 
 #Create the output directory if it doesn't exist

--- a/kraken/ketos.py
+++ b/kraken/ketos.py
@@ -25,7 +25,7 @@ import unicodedata
 from click import open_file
 from bidi.algorithm import get_display
 
-from typing import cast, Set, List, IO, Any
+from typing import cast, Set, List, IO, Any, Dict
 from collections import defaultdict
 
 from kraken.lib import log

--- a/kraken/lib/dataset.py
+++ b/kraken/lib/dataset.py
@@ -692,7 +692,7 @@ class GroundTruthDataset(Dataset):
         """
         if self.preload:
             try:
-                im = self.head_transforms(im)
+                im = self.head_transforms(image)
                 if not is_bitonal(im):
                     self.im_mode = im.mode
                 im = self.tail_transforms(im)

--- a/kraken/lib/train.py
+++ b/kraken/lib/train.py
@@ -814,9 +814,9 @@ class KrakenTrainer(object):
             tr_it.add_phase(int(len(gt_set) * hyper_params['epochs']),
                             annealing_exp)
         elif hyper_params['schedule'] == 'step':
-            annealing_step = partial(annealing_step, step_size=hyper_params['step_size'], gamma=hyper_params['gamma'])
+            annealing_step_p = partial(annealing_step, step_size=hyper_params['step_size'], gamma=hyper_params['gamma'])
             tr_it.add_phase(int(len(gt_set) * hyper_params['epochs']),
-                            annealing_step)
+                            annealing_step_p)
         elif hyper_params['schedule'] == 'reduceonplateau':
             annealing_red = partial(annealing_reduceonplateau, patience=hyper_params['rop_patience'], factor=hyper_params['gamma'])
             tr_it.add_phase(int(len(gt_set) * hyper_params['epochs']),
@@ -1134,9 +1134,9 @@ class KrakenTrainer(object):
             tr_it.add_phase(int(len(gt_set) * hyper_params['epochs']),
                             annealing_exp)
         elif hyper_params['schedule'] == 'step':
-            annealing_step = partial(annealing_step, step_size=hyper_params['step_size'], gamma=hyper_params['gamma'])
+            annealing_step_p = partial(annealing_step, step_size=hyper_params['step_size'], gamma=hyper_params['gamma'])
             tr_it.add_phase(int(len(gt_set) * hyper_params['epochs']),
-                            annealing_step)
+                            annealing_step_p)
         elif hyper_params['schedule'] == 'reduceonplateau':
             annealing_red = partial(annealing_reduceonplateau, patience=hyper_params['rop_patience'], factor=hyper_params['gamma'])
             tr_it.add_phase(int(len(gt_set) * hyper_params['epochs']),

--- a/tests/test_readingorder.py
+++ b/tests/test_readingorder.py
@@ -62,13 +62,16 @@ class TestReadingOrder(unittest.TestCase):
 
             BBBB
         
+        The reading order should be the same for left-to-right and right-to-left.
         """
         polygon0 = [[10, 10], [10, 20], [100, 20], [100, 10], [10, 10]]
         polygon1 = [[10, 30], [10, 40], [100, 40], [100, 30], [10, 30]]
-        order = reading_order([polygon_slices(line) for line in [polygon0, polygon1]])
+        order_lr = reading_order([polygon_slices(line) for line in [polygon0, polygon1]])
+        order_rl = reading_order([polygon_slices(line) for line in [polygon0, polygon1]], 'rl')
         # line0 should come before line1, lines do not come before themselves
         expected = np.array([[0, 1], [0, 0]])
-        self.assertTrue(np.array_equal(order, expected), "Reading order is not as expected: {}".format(order))
+        self.assertTrue(np.array_equal(order_lr, expected), "Reading order is not as expected: {}".format(order_lr))
+        self.assertTrue(np.array_equal(order_rl, expected), "Reading order is not as expected: {}".format(order_rl))
 
     def test_order_simple_over_under_touching(self):
         """
@@ -79,13 +82,16 @@ class TestReadingOrder(unittest.TestCase):
             AAAA
             BBBB
         
+        The reading order should be the same for left-to-right and right-to-left.
         """
         polygon0 = [[10, 10], [10, 30], [100, 30], [100, 10], [10, 10]]
         polygon1 = [[10, 30], [10, 40], [100, 40], [100, 30], [10, 30]]
-        order = reading_order([polygon_slices(line) for line in [polygon0, polygon1]])
+        order_lr = reading_order([polygon_slices(line) for line in [polygon0, polygon1]])
+        order_rl = reading_order([polygon_slices(line) for line in [polygon0, polygon1]], 'rl')
         # line0 should come before line1, lines do not come before themselves
         expected = np.array([[0, 1], [0, 0]])
-        self.assertTrue(np.array_equal(order, expected), "Reading order is not as expected: {}".format(order))
+        self.assertTrue(np.array_equal(order_lr, expected), "Reading order is not as expected: {}".format(order_lr))
+        self.assertTrue(np.array_equal(order_rl, expected), "Reading order is not as expected: {}".format(order_rl))
 
     def test_order_simple_left_right(self):
         """
@@ -122,24 +128,30 @@ class TestReadingOrder(unittest.TestCase):
     def test_order_real_reverse(self):
         """
         Real example: lines are in reverse order.
+        The reading order should be the same for left-to-right and right-to-left.
         """
         polygon0 = [[474, 2712], [466, 2669], [1741, 2655], [1749, 2696], [1746, 2709], [474, 2725]]
         polygon1 = [[493, 2409], [488, 2374], [1733, 2361], [1741, 2395], [1738, 2409], [493, 2422]]
-        order = reading_order([polygon_slices(line) for line in [polygon0, polygon1]])
+        order_lr = reading_order([polygon_slices(line) for line in [polygon0, polygon1]])
+        order_rl = reading_order([polygon_slices(line) for line in [polygon0, polygon1]], 'rl')
         # line1 should come before line0, lines do not come before themselves
         expected = np.array([[0, 0], [1, 0]])
-        self.assertTrue(np.array_equal(order, expected), "Reading order is not as expected: {}".format(order))
+        self.assertTrue(np.array_equal(order_lr, expected), "Reading order is not as expected: {}".format(order_lr))
+        self.assertTrue(np.array_equal(order_rl, expected), "Reading order is not as expected: {}".format(order_rl))
     
     def test_order_real_in_order(self):
         """
         Real (modified) example: lines are in order.
+        The reading order should be the same for left-to-right and right-to-left.
         """
         polygon0 = [[493, 2409], [488, 2374], [1733, 2361], [1741, 2395], [1738, 2409], [493, 2422]]
         polygon1 = [[474, 2712], [466, 2669], [1741, 2655], [1749, 2696], [1746, 2709], [474, 2725]]
-        order = reading_order([polygon_slices(line) for line in [polygon0, polygon1]])
+        order_lr = reading_order([polygon_slices(line) for line in [polygon0, polygon1]])
+        order_rl = reading_order([polygon_slices(line) for line in [polygon0, polygon1]], 'rl')
         # line0 should come before line1, lines do not come before themselves
         expected = np.array([[0, 1], [0, 0]])
-        self.assertTrue(np.array_equal(order, expected), "Reading order is not as expected: {}".format(order))
+        self.assertTrue(np.array_equal(order_lr, expected), "Reading order is not as expected: {}".format(order_lr))
+        self.assertTrue(np.array_equal(order_rl, expected), "Reading order is not as expected: {}".format(order_rl))
 
     def test_topsort_ordered(self):
         """

--- a/tests/test_readingorder.py
+++ b/tests/test_readingorder.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function
 
 import unittest
 import os
+from typing import Sequence, Tuple
 
 import shapely.geometry as geom
 import numpy as np
@@ -12,6 +13,14 @@ from kraken.lib.segmentation import is_in_region, reading_order, topsort
 
 thisfile = os.path.abspath(os.path.dirname(__file__))
 resources = os.path.abspath(os.path.join(thisfile, 'resources'))
+
+
+def polygon_slices(polygon: Sequence) -> Tuple:
+    """Convert polygons to slices for reading_order"""
+    linestr = geom.LineString(polygon)
+    slices = (slice(linestr.bounds[1], linestr.bounds[0]),
+             slice(linestr.bounds[3], linestr.bounds[2]))
+    return slices
 
 
 class TestReadingOrder(unittest.TestCase):
@@ -55,12 +64,8 @@ class TestReadingOrder(unittest.TestCase):
         
         """
         polygon0 = [[10, 10], [10, 20], [100, 20], [100, 10], [10, 10]]
-        linestr0 = geom.LineString(polygon0)
-        line0 = (slice(linestr0.bounds[1], linestr0.bounds[0]), slice(linestr0.bounds[3], linestr0.bounds[2]))
         polygon1 = [[10, 30], [10, 40], [100, 40], [100, 30], [10, 30]]
-        linestr1 = geom.LineString(polygon1)
-        line1 = (slice(linestr1.bounds[1], linestr1.bounds[0]), slice(linestr1.bounds[3], linestr1.bounds[2]))
-        order = reading_order([line0, line1])
+        order = reading_order([polygon_slices(line) for line in [polygon0, polygon1]])
         # line0 should come before line1, lines do not come before themselves
         expected = np.array([[0, 1], [0, 0]])
         self.assertTrue(np.array_equal(order, expected), "Reading order is not as expected: {}".format(order))
@@ -76,12 +81,8 @@ class TestReadingOrder(unittest.TestCase):
         
         """
         polygon0 = [[10, 10], [10, 30], [100, 30], [100, 10], [10, 10]]
-        linestr0 = geom.LineString(polygon0)
-        line0 = (slice(linestr0.bounds[1], linestr0.bounds[0]), slice(linestr0.bounds[3], linestr0.bounds[2]))
         polygon1 = [[10, 30], [10, 40], [100, 40], [100, 30], [10, 30]]
-        linestr1 = geom.LineString(polygon1)
-        line1 = (slice(linestr1.bounds[1], linestr1.bounds[0]), slice(linestr1.bounds[3], linestr1.bounds[2]))
-        order = reading_order([line0, line1])
+        order = reading_order([polygon_slices(line) for line in [polygon0, polygon1]])
         # line0 should come before line1, lines do not come before themselves
         expected = np.array([[0, 1], [0, 0]])
         self.assertTrue(np.array_equal(order, expected), "Reading order is not as expected: {}".format(order))
@@ -96,12 +97,8 @@ class TestReadingOrder(unittest.TestCase):
         
         """
         polygon0 = [[10, 10], [10, 20], [100, 20], [100, 10], [10, 10]]
-        linestr0 = geom.LineString(polygon0)
-        line0 = (slice(linestr0.bounds[1], linestr0.bounds[0]), slice(linestr0.bounds[3], linestr0.bounds[2]))
         polygon1 = [[150, 10], [150, 20], [250, 20], [250, 10], [150, 10]]
-        linestr1 = geom.LineString(polygon1)
-        line1 = (slice(linestr1.bounds[1], linestr1.bounds[0]), slice(linestr1.bounds[3], linestr1.bounds[2]))
-        order = reading_order([line0, line1])
+        order = reading_order([polygon_slices(line) for line in [polygon0, polygon1]])
         # line0 should come before line1, lines do not come before themselves
         expected = np.array([[0, 1], [0, 0]])
         self.assertTrue(np.array_equal(order, expected), "Reading order is not as expected: {}".format(order))
@@ -116,12 +113,8 @@ class TestReadingOrder(unittest.TestCase):
         
         """
         polygon0 = [[10, 10], [10, 20], [100, 20], [100, 10], [10, 10]]
-        linestr0 = geom.LineString(polygon0)
-        line0 = (slice(linestr0.bounds[1], linestr0.bounds[0]), slice(linestr0.bounds[3], linestr0.bounds[2]))
         polygon1 = [[100, 10], [100, 20], [250, 20], [250, 10], [100, 10]]
-        linestr1 = geom.LineString(polygon1)
-        line1 = (slice(linestr1.bounds[1], linestr1.bounds[0]), slice(linestr1.bounds[3], linestr1.bounds[2]))
-        order = reading_order([line0, line1])
+        order = reading_order([polygon_slices(line) for line in [polygon0, polygon1]])
         # line0 should come before line1, lines do not come before themselves
         expected = np.array([[0, 1], [0, 0]])
         self.assertTrue(np.array_equal(order, expected), "Reading order is not as expected: {}".format(order))
@@ -131,12 +124,8 @@ class TestReadingOrder(unittest.TestCase):
         Real example: lines are in reverse order.
         """
         polygon0 = [[474, 2712], [466, 2669], [1741, 2655], [1749, 2696], [1746, 2709], [474, 2725]]
-        linestr0 = geom.LineString(polygon0)
-        line0 = (slice(linestr0.bounds[1], linestr0.bounds[0]), slice(linestr0.bounds[3], linestr0.bounds[2]))
         polygon1 = [[493, 2409], [488, 2374], [1733, 2361], [1741, 2395], [1738, 2409], [493, 2422]]
-        linestr1 = geom.LineString(polygon1)
-        line1 = (slice(linestr1.bounds[1], linestr1.bounds[0]), slice(linestr1.bounds[3], linestr1.bounds[2]))
-        order = reading_order([line0, line1])
+        order = reading_order([polygon_slices(line) for line in [polygon0, polygon1]])
         # line1 should come before line0, lines do not come before themselves
         expected = np.array([[0, 0], [1, 0]])
         self.assertTrue(np.array_equal(order, expected), "Reading order is not as expected: {}".format(order))
@@ -146,12 +135,8 @@ class TestReadingOrder(unittest.TestCase):
         Real (modified) example: lines are in order.
         """
         polygon0 = [[493, 2409], [488, 2374], [1733, 2361], [1741, 2395], [1738, 2409], [493, 2422]]
-        linestr0 = geom.LineString(polygon0)
-        line0 = (slice(linestr0.bounds[1], linestr0.bounds[0]), slice(linestr0.bounds[3], linestr0.bounds[2]))
         polygon1 = [[474, 2712], [466, 2669], [1741, 2655], [1749, 2696], [1746, 2709], [474, 2725]]
-        linestr1 = geom.LineString(polygon1)
-        line1 = (slice(linestr1.bounds[1], linestr1.bounds[0]), slice(linestr1.bounds[3], linestr1.bounds[2]))
-        order = reading_order([line0, line1])
+        order = reading_order([polygon_slices(line) for line in [polygon0, polygon1]])
         # line0 should come before line1, lines do not come before themselves
         expected = np.array([[0, 1], [0, 0]])
         self.assertTrue(np.array_equal(order, expected), "Reading order is not as expected: {}".format(order))

--- a/tests/test_readingorder.py
+++ b/tests/test_readingorder.py
@@ -1,0 +1,189 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function
+
+import unittest
+import os
+
+import shapely.geometry as geom
+import numpy as np
+
+from kraken.lib.segmentation import is_in_region, reading_order, topsort
+
+thisfile = os.path.abspath(os.path.dirname(__file__))
+resources = os.path.abspath(os.path.join(thisfile, 'resources'))
+
+
+class TestReadingOrder(unittest.TestCase):
+
+    """
+    Test the reading order algorithms.
+    """
+    def test_is_in_region(self):
+        """
+        A line should be in its rectangular bounding box.
+        """
+        line = geom.LineString([(0, 0), (1, 1)])
+        polygon = geom.Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
+        self.assertTrue(is_in_region(line, polygon))
+    
+    def test_is_in_region2(self):
+        """
+        A real baseline should be in its polygonization.
+        """
+        line = geom.LineString([(268,656), (888,656)])
+        polygon = geom.Polygon([(268,656), (265,613), (885,611), (888,656), (885,675), (265,672)])
+        self.assertTrue(is_in_region(line, polygon))
+    
+    def test_is_in_region3(self):
+        """
+        A line that does not cross the box should not be in the region.
+        """
+        line = geom.LineString([(2, 2), (1, 1)])
+        polygon = geom.Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
+        self.assertFalse(is_in_region(line, polygon))
+
+    def test_order_simple_over_under(self):
+        """
+        Two lines (as their polygonal boundaries) are already in order.
+        In this example, the boundaries are rectangles that align vertically,
+        have horizontal base lines and do not overlap or touch::
+
+            AAAA
+
+            BBBB
+        
+        """
+        polygon0 = [[10, 10], [10, 20], [100, 20], [100, 10], [10, 10]]
+        linestr0 = geom.LineString(polygon0)
+        line0 = (slice(linestr0.bounds[1], linestr0.bounds[0]), slice(linestr0.bounds[3], linestr0.bounds[2]))
+        polygon1 = [[10, 30], [10, 40], [100, 40], [100, 30], [10, 30]]
+        linestr1 = geom.LineString(polygon1)
+        line1 = (slice(linestr1.bounds[1], linestr1.bounds[0]), slice(linestr1.bounds[3], linestr1.bounds[2]))
+        order = reading_order([line0, line1])
+        # line0 should come before line1, lines do not come before themselves
+        expected = np.array([[0, 1], [0, 0]])
+        self.assertTrue(np.array_equal(order, expected), "Reading order is not as expected: {}".format(order))
+
+    def test_order_simple_over_under_touching(self):
+        """
+        Two lines (as their polygonal boundaries) are already in order.
+        In this example, the boundaries are rectangles that align vertically,
+        have horizontal base lines and touch::
+
+            AAAA
+            BBBB
+        
+        """
+        polygon0 = [[10, 10], [10, 30], [100, 30], [100, 10], [10, 10]]
+        linestr0 = geom.LineString(polygon0)
+        line0 = (slice(linestr0.bounds[1], linestr0.bounds[0]), slice(linestr0.bounds[3], linestr0.bounds[2]))
+        polygon1 = [[10, 30], [10, 40], [100, 40], [100, 30], [10, 30]]
+        linestr1 = geom.LineString(polygon1)
+        line1 = (slice(linestr1.bounds[1], linestr1.bounds[0]), slice(linestr1.bounds[3], linestr1.bounds[2]))
+        order = reading_order([line0, line1])
+        # line0 should come before line1, lines do not come before themselves
+        expected = np.array([[0, 1], [0, 0]])
+        self.assertTrue(np.array_equal(order, expected), "Reading order is not as expected: {}".format(order))
+
+    def test_order_simple_left_right(self):
+        """
+        Two lines (as their polygonal boundaries) are already in order.
+        In this example, the boundaries are rectangles that align horizontally,
+        have horizontal base lines and do not overlap or touch::
+
+            AAAA  BBBB
+        
+        """
+        polygon0 = [[10, 10], [10, 20], [100, 20], [100, 10], [10, 10]]
+        linestr0 = geom.LineString(polygon0)
+        line0 = (slice(linestr0.bounds[1], linestr0.bounds[0]), slice(linestr0.bounds[3], linestr0.bounds[2]))
+        polygon1 = [[150, 10], [150, 20], [250, 20], [250, 10], [150, 10]]
+        linestr1 = geom.LineString(polygon1)
+        line1 = (slice(linestr1.bounds[1], linestr1.bounds[0]), slice(linestr1.bounds[3], linestr1.bounds[2]))
+        order = reading_order([line0, line1])
+        # line0 should come before line1, lines do not come before themselves
+        expected = np.array([[0, 1], [0, 0]])
+        self.assertTrue(np.array_equal(order, expected), "Reading order is not as expected: {}".format(order))
+
+    def test_order_simple_left_right_touching(self):
+        """
+        Two lines (as their polygonal boundaries) are already in order.
+        In this example, the boundaries are rectangles that align horizontally,
+        have horizontal base lines and touch::
+
+            AAAA  BBBB
+        
+        """
+        polygon0 = [[10, 10], [10, 20], [100, 20], [100, 10], [10, 10]]
+        linestr0 = geom.LineString(polygon0)
+        line0 = (slice(linestr0.bounds[1], linestr0.bounds[0]), slice(linestr0.bounds[3], linestr0.bounds[2]))
+        polygon1 = [[100, 10], [100, 20], [250, 20], [250, 10], [100, 10]]
+        linestr1 = geom.LineString(polygon1)
+        line1 = (slice(linestr1.bounds[1], linestr1.bounds[0]), slice(linestr1.bounds[3], linestr1.bounds[2]))
+        order = reading_order([line0, line1])
+        # line0 should come before line1, lines do not come before themselves
+        expected = np.array([[0, 1], [0, 0]])
+        self.assertTrue(np.array_equal(order, expected), "Reading order is not as expected: {}".format(order))
+
+    def test_order_real_reverse(self):
+        """
+        Real example: lines are in reverse order.
+        """
+        polygon0 = [[474, 2712], [466, 2669], [1741, 2655], [1749, 2696], [1746, 2709], [474, 2725]]
+        linestr0 = geom.LineString(polygon0)
+        line0 = (slice(linestr0.bounds[1], linestr0.bounds[0]), slice(linestr0.bounds[3], linestr0.bounds[2]))
+        polygon1 = [[493, 2409], [488, 2374], [1733, 2361], [1741, 2395], [1738, 2409], [493, 2422]]
+        linestr1 = geom.LineString(polygon1)
+        line1 = (slice(linestr1.bounds[1], linestr1.bounds[0]), slice(linestr1.bounds[3], linestr1.bounds[2]))
+        order = reading_order([line0, line1])
+        # line1 should come before line0, lines do not come before themselves
+        expected = np.array([[0, 0], [1, 0]])
+        self.assertTrue(np.array_equal(order, expected), "Reading order is not as expected: {}".format(order))
+    
+    def test_order_real_in_order(self):
+        """
+        Real (modified) example: lines are in order.
+        """
+        polygon0 = [[493, 2409], [488, 2374], [1733, 2361], [1741, 2395], [1738, 2409], [493, 2422]]
+        linestr0 = geom.LineString(polygon0)
+        line0 = (slice(linestr0.bounds[1], linestr0.bounds[0]), slice(linestr0.bounds[3], linestr0.bounds[2]))
+        polygon1 = [[474, 2712], [466, 2669], [1741, 2655], [1749, 2696], [1746, 2709], [474, 2725]]
+        linestr1 = geom.LineString(polygon1)
+        line1 = (slice(linestr1.bounds[1], linestr1.bounds[0]), slice(linestr1.bounds[3], linestr1.bounds[2]))
+        order = reading_order([line0, line1])
+        # line0 should come before line1, lines do not come before themselves
+        expected = np.array([[0, 1], [0, 0]])
+        self.assertTrue(np.array_equal(order, expected), "Reading order is not as expected: {}".format(order))
+
+    def test_topsort_ordered(self):
+        """
+        Return list for three lines that are already in order.
+        """
+        partial_sort = np.array([[1,1,1], [0,1,1], [0,0,1]])
+        expected = [0,1,2]
+        self.assertTrue(np.array_equal(topsort(partial_sort), expected))
+
+    def test_topsort_ordered_no_self(self):
+        """
+        Return list for three lines that are already in order.
+        """
+        partial_sort = np.array([[0,1,1], [0,0,1], [0,0,0]])
+        expected = [0,1,2]
+        self.assertTrue(np.array_equal(topsort(partial_sort), expected))
+
+    def test_topsort_unordered(self):
+        """
+        Return list for three lines that are partially in order.
+        """
+        partial_sort = np.array([[1,1,1], [0,1,0], [0,1,1]])
+        expected = [0,2,1]
+        self.assertTrue(np.array_equal(topsort(partial_sort), expected))
+
+    def test_topsort_unordered_no_self(self):
+        """
+        Return list for three lines that are partially in order.
+        """
+        partial_sort = np.array([[0,1,1], [0,0,0], [0,1,0]])
+        expected = [0,2,1]
+        self.assertTrue(np.array_equal(topsort(partial_sort), expected))

--- a/tests/test_readingorder.py
+++ b/tests/test_readingorder.py
@@ -112,7 +112,7 @@ class TestReadingOrder(unittest.TestCase):
         In this example, the boundaries are rectangles that align horizontally,
         have horizontal base lines and touch::
 
-            AAAA  BBBB
+            AAAABBBB
         
         """
         polygon0 = [[10, 10], [10, 20], [100, 20], [100, 10], [10, 10]]


### PR DESCRIPTION
These tests try to determine what goes wrong in finding the reading order. This relates to #269, #278 and other issues.
Currently, the `test_is_in_region*` and `test_topsort*` tests pass and only some of the `test_order*` tests pass.

That leads me to believe that something goes wrong in the `reading_order` function, because it doesn't always produce sensible partial reading orders, like `[[0,0],[0,0]]` or `[[1,1],[1,1]]`.

The transformation of (fake) polygonizations of baselines to slices to go into `reading_order` is taken from `polygonal_reading_order`.

After pip-installing `hocr-spec`, `pytest` and `nose`, I can run these tests with `pytest tests/test_readingorder.py`.

