### PR TITLE
Add more typing and reading order tests

### DIFF
--- a/kraken/align.py
+++ b/kraken/align.py
@@ -63,12 +63,12 @@ def _shortest_path(graph):
     return fst.shortestpath(graph)
 
 
-def fst_from_lattice(outputs: np.array):
+def fst_from_lattice(outputs: np.ndarray):
     """
     Generates an FST from the network output tensor.
 
     Arguments:
-        outputs (np.array): Output tensor of shape (Batch, Labels, Length).
+        outputs (np.ndarray): Output tensor of shape (Batch, Labels, Length).
 
     Returns:
         An OpenFST FST object.

--- a/kraken/binarization.py
+++ b/kraken/binarization.py
@@ -75,7 +75,7 @@ def nlbin(im: Image.Image,
     raw = pil2array(im)
     logger.debug('Scaling and normalizing')
     # rescale image to between -1 or 0 and 1
-    raw = raw/np.float(np.iinfo(raw.dtype).max)
+    raw = raw/float(np.iinfo(raw.dtype).max)
     # perform image normalization
     if np.amax(raw) == np.amin(raw):
         logger.warning(f'Trying to binarize empty image {im_str}')

--- a/kraken/binarization.py
+++ b/kraken/binarization.py
@@ -43,7 +43,7 @@ def nlbin(im: Image.Image,
           perc: int = 80,
           range: int = 20,
           low: int = 5,
-          high: int = 90) -> Image:
+          high: int = 90) -> Image.Image:
     """
     Performs binarization using non-linear processing.
 
@@ -59,7 +59,7 @@ def nlbin(im: Image.Image,
         high (int): Percentile for white estimation
 
     Returns:
-        PIL.Image containing the binarized image
+        PIL.Image.Image containing the binarized image
 
     Raises:
         KrakenInputException when trying to binarize an empty image.

--- a/kraken/blla.py
+++ b/kraken/blla.py
@@ -48,7 +48,7 @@ logger = logging.getLogger(__name__)
 
 
 def compute_segmentation_map(im,
-                             mask: Optional[np.array] = None,
+                             mask: Optional[np.ndarray] = None,
                              model=None,
                              device: str = 'cpu'):
     """
@@ -117,7 +117,7 @@ def vec_lines(heatmap: torch.Tensor,
               text_direction: str = 'horizontal-lr',
               reading_order_fn: Callable = polygonal_reading_order,
               regions: List = None,
-              scal_im: np.array = None,
+              scal_im: np.ndarray = None,
               suppl_obj: List = None,
               topline: bool = False,
               **kwargs):
@@ -162,7 +162,7 @@ def vec_lines(heatmap: torch.Tensor,
 
 def segment(im,
             text_direction: str = 'horizontal-lr',
-            mask: Optional[np.array] = None,
+            mask: Optional[np.ndarray] = None,
             reading_order_fn: Callable = polygonal_reading_order,
             model: Union[List[vgsl.TorchVGSLModel], vgsl.TorchVGSLModel] = None,
             device: str = 'cpu'):

--- a/kraken/lib/dataset.py
+++ b/kraken/lib/dataset.py
@@ -1022,20 +1022,20 @@ class BaselineSet(Dataset):
                 line = np.array(line)*scale
                 shp_line = geom.LineString(line)
                 split_offset = min(5, shp_line.length/2)
-                line_pol = np.array(shp_line.buffer(self.line_width/2, cap_style=2).boundary, dtype=np.int)
+                line_pol = np.array(shp_line.buffer(self.line_width/2, cap_style=2).boundary, dtype=int)
                 rr, cc = polygon(line_pol[:, 1], line_pol[:, 0], shape=image.shape[1:])
                 t[cls_idx, rr, cc] = 1
                 split_pt = shp_line.interpolate(split_offset).buffer(0.001)
                 # top
                 start_sep = np.array((split(shp_line, split_pt)[0].buffer(self.line_width,
-                                                                          cap_style=3).boundary), dtype=np.int)
+                                                                          cap_style=3).boundary), dtype=int)
                 rr_s, cc_s = polygon(start_sep[:, 1], start_sep[:, 0], shape=image.shape[1:])
                 t[start_sep_cls, rr_s, cc_s] = 1
                 t[start_sep_cls, rr, cc] = 0
                 split_pt = shp_line.interpolate(-split_offset).buffer(0.001)
                 # top
                 end_sep = np.array((split(shp_line, split_pt)[-1].buffer(self.line_width,
-                                                                         cap_style=3).boundary), dtype=np.int)
+                                                                         cap_style=3).boundary), dtype=int)
                 rr_s, cc_s = polygon(end_sep[:, 1], end_sep[:, 0], shape=image.shape[1:])
                 t[end_sep_cls, rr_s, cc_s] = 1
                 t[end_sep_cls, rr, cc] = 0

--- a/kraken/lib/layers.py
+++ b/kraken/lib/layers.py
@@ -285,7 +285,7 @@ class Dropout(Module):
         elif dim == 2:
             self.layer = torch.nn.Dropout2d(p)
 
-    def forward(self, inputs: torch.Tensor, seq_len: torch.Tensor = None) -> Tuple[torch.tensor, torch.Tensor]:
+    def forward(self, inputs: torch.Tensor, seq_len: torch.Tensor = None) -> Tuple[torch.Tensor, torch.Tensor]:
         return self.layer(inputs), seq_len
 
     def get_shape(self, input: Tuple[int, int, int, int]) -> Tuple[int, int, int, int]:

--- a/kraken/lib/models.py
+++ b/kraken/lib/models.py
@@ -62,7 +62,7 @@ class TorchSeqRecognizer(object):
         self.device = device
         self.nn.to(device)
 
-    def forward(self, line: torch.Tensor, lens: torch.Tensor = None) -> np.array:
+    def forward(self, line: torch.Tensor, lens: torch.Tensor = None) -> np.ndarray:
         """
         Performs a forward pass on a torch tensor of one or more lines with
         shape (N, C, H, W) and returns a numpy array (N, W, C).

--- a/kraken/lib/morph.py
+++ b/kraken/lib/morph.py
@@ -5,7 +5,7 @@ import numpy as np
 from scipy.ndimage import morphology, measurements, filters
 
 
-def label(image: np.array, **kw) -> np.array:
+def label(image: np.ndarray, **kw) -> np.ndarray:
     """
     Redefine the scipy.ndimage.measurements.label function to work with a wider
     range of data types.  The default function is inconsistent about the data
@@ -25,7 +25,7 @@ def label(image: np.array, **kw) -> np.array:
     return measurements.label(image, **kw)
 
 
-def find_objects(image: np.array, **kw) -> np.array:
+def find_objects(image: np.ndarray, **kw) -> np.ndarray:
     """
     Redefine the scipy.ndimage.measurements.find_objects function to work with
     a wider range of data types.  The default function is inconsistent about

--- a/kraken/lib/segmentation.py
+++ b/kraken/lib/segmentation.py
@@ -459,7 +459,7 @@ def _calc_seam(baseline, polygon, angle, im_feats, bias=150):
         mask[line_locs] = 0
     dist_bias = distance_transform_cdt(mask)
     # absolute mask
-    mask = np.ones_like(patch, dtype=np.bool)
+    mask = np.ones_like(patch, dtype=bool)
     mask[r-r_min, c-c_min] = False
     # dilate mask to compensate for aliasing during rotation
     mask = binary_erosion(mask, iterations=2)
@@ -954,7 +954,7 @@ def extract_polygons(im: Image.Image, bounds: Dict[str, Any]) -> Image:
                 patch = im[r_min:r_max+1, c_min:c_max+1].copy()
                 offset_polygon = pl - (c_min, r_min)
                 r, c = draw.polygon(offset_polygon[:, 1], offset_polygon[:, 0])
-                mask = np.zeros(patch.shape[:2], dtype=np.bool)
+                mask = np.zeros(patch.shape[:2], dtype=bool)
                 mask[r, c] = True
                 patch[mask != True] = 0
                 extrema = offset_polygon[(0, -1), :]
@@ -1006,7 +1006,7 @@ def extract_polygons(im: Image.Image, bounds: Dict[str, Any]) -> Image:
                 offset_bl_dst_pts = bl_dst_pts - (c_dst_min, r_dst_min)
                 offset_pol_dst_pts = pol_dst_pts - (c_dst_min, r_dst_min)
                 # mask out points outside bounding polygon
-                mask = np.zeros(patch.shape[:2], dtype=np.bool)
+                mask = np.zeros(patch.shape[:2], dtype=bool)
                 r, c = draw.polygon(offset_polygon[:, 1], offset_polygon[:, 0])
                 mask[r, c] = True
                 patch[mask != True] = 0

--- a/kraken/lib/segmentation.py
+++ b/kraken/lib/segmentation.py
@@ -61,7 +61,7 @@ __all__ = ['reading_order',
            'extract_polygons']
 
 
-def reading_order(lines: Sequence, text_direction: str = 'lr') -> List:
+def reading_order(lines: Sequence[Tuple[slice, slice]], text_direction: str = 'lr') -> np.ndarray:
     """Given the list of lines (a list of 2D slices), computes
     the partial reading order.  The output is a binary 2D array
     such that order[i,j] is true if line i comes before line j
@@ -107,7 +107,7 @@ def reading_order(lines: Sequence, text_direction: str = 'lr') -> List:
     return order
 
 
-def topsort(order: np.array) -> np.array:
+def topsort(order: np.ndarray) -> List[int]:
     """Given a binary array defining a partial order (o[i,j]==True means i<j),
     compute a topological sort.  This is a quick and dirty implementation
     that works for up to a few thousand elements."""
@@ -607,7 +607,7 @@ def _calc_roi(line, bounds, baselines, suppl_obj, p_dir):
 def calculate_polygonal_environment(im: PIL.Image.Image = None,
                                     baselines: Sequence[Sequence[Tuple[int, int]]] = None,
                                     suppl_obj: Sequence[Sequence[Tuple[int, int]]] = None,
-                                    im_feats: np.array = None,
+                                    im_feats: np.ndarray = None,
                                     scale: Tuple[int, int] = None,
                                     topline: bool = False):
     """
@@ -782,7 +782,7 @@ def is_in_region(line, region) -> bool:
     return region.contains(l_obj)
 
 
-def scale_regions(regions: Sequence[Tuple[List, List]],
+def scale_regions(regions: Sequence[Tuple[List[int], List[int]]],
                   scale: Union[float, Tuple[float, float]]) -> Sequence[Tuple[List, List]]:
     """
     Scales baselines/polygon coordinates by a certain factor.

--- a/kraken/lib/segmentation.py
+++ b/kraken/lib/segmentation.py
@@ -705,9 +705,9 @@ def calculate_polygonal_environment(im: PIL.Image.Image = None,
     return polygons
 
 
-def polygonal_reading_order(lines: Sequence[Tuple[List, List]],
+def polygonal_reading_order(lines: Sequence[Tuple[List[Tuple[int, int]], List[Tuple[int, int]]]],
                             text_direction: str = 'lr',
-                            regions: Optional[Sequence[List[Tuple[int, int]]]] = None) -> Sequence[Tuple[List, List]]:
+                            regions: Optional[Sequence[List[Tuple[int, int]]]] = None) -> Sequence[Tuple[List[Tuple[int, int]], List[Tuple[int, int]]]]:
     """
     Given a list of baselines and regions, calculates the correct reading order
     and applies it to the input.

--- a/kraken/lib/segmentation.py
+++ b/kraken/lib/segmentation.py
@@ -656,12 +656,12 @@ def calculate_polygonal_environment(im: PIL.Image.Image = None,
             suppl_obj = [(np.array(bl) * scale).astype('int').tolist() for bl in suppl_obj]
 
     if im_feats is None:
-        bounds = np.array(im.size, dtype=np.float) - 1
+        bounds = np.array(im.size, dtype=float) - 1
         im = np.array(im.convert('L'))
         # compute image gradient
         im_feats = gaussian_filter(sobel(im), 0.5)
     else:
-        bounds = np.array(im_feats.shape[::-1], dtype=np.float) - 1
+        bounds = np.array(im_feats.shape[::-1], dtype=float) - 1
 
     polygons = []
     if suppl_obj is None:
@@ -673,8 +673,8 @@ def calculate_polygonal_environment(im: PIL.Image.Image = None,
             line = geom.LineString(line)
             offset = default_specs.SEGMENTATION_HYPER_PARAMS['line_width'] if topline is not None else 0
             offset_line = line.parallel_offset(offset, side='left' if topline else 'right')
-            line = np.array(line, dtype=np.float)
-            offset_line = np.array(offset_line, dtype=np.float)
+            line = np.array(line, dtype=float)
+            offset_line = np.array(offset_line, dtype=float)
 
             # parallel_offset on the right reverses the coordinate order
             if not topline:

--- a/kraken/lib/segmentation.py
+++ b/kraken/lib/segmentation.py
@@ -906,7 +906,7 @@ def compute_polygon_section(baseline, boundary, dist1, dist2):
     return o
 
 
-def extract_polygons(im: Image.Image, bounds: Dict[str, Any]) -> Image:
+def extract_polygons(im: Image.Image, bounds: Dict[str, Any]) -> Image.Image:
     """
     Yields the subimages of image im defined in the list of bounding polygons
     with baselines preserving order.
@@ -916,7 +916,7 @@ def extract_polygons(im: Image.Image, bounds: Dict[str, Any]) -> Image:
         bounds (list): A list of tuples (x1, y1, x2, y2)
 
     Yields:
-        (PIL.Image) the extracted subimage
+        (PIL.Image.Image) the extracted subimage
     """
     if 'type' in bounds and bounds['type'] == 'baselines':
         # select proper interpolation scheme depending on shape

--- a/kraken/lib/segmentation.py
+++ b/kraken/lib/segmentation.py
@@ -530,13 +530,13 @@ def _extract_patch(env_up, env_bottom, baseline, offset_baseline, end_points, di
     # ugly workaround against GEOM parallel_offset bug creating a
     # MultiLineString out of offset LineString
     if upper_seam.parallel_offset(offset//2, side='right').type == 'MultiLineString' or offset == 0:
-        upper_seam = np.array(upper_seam, dtype=np.int)
+        upper_seam = np.array(upper_seam, dtype=int)
     else:
-        upper_seam = np.array(upper_seam.parallel_offset(offset//2, side='right'), dtype=np.int)[::-1]
+        upper_seam = np.array(upper_seam.parallel_offset(offset//2, side='right'), dtype=int)[::-1]
     if bottom_seam.parallel_offset(offset//2, side='left').type == 'MultiLineString' or offset == 0:
-        bottom_seam = np.array(bottom_seam, dtype=np.int)
+        bottom_seam = np.array(bottom_seam, dtype=int)
     else:
-        bottom_seam = np.array(bottom_seam.parallel_offset(offset//2, side='left'), dtype=np.int)
+        bottom_seam = np.array(bottom_seam.parallel_offset(offset//2, side='left'), dtype=int)
 
     polygon = np.concatenate(([end_points[0]], upper_seam, [end_points[-1]], bottom_seam[::-1]))
     return polygon

--- a/kraken/lib/util.py
+++ b/kraken/lib/util.py
@@ -16,7 +16,7 @@ def pil2array(im: Image.Image, alpha: int = 0) -> np.ndarray:
     return np.array(im)
 
 
-def array2pil(a: np.ndarray) -> Image:
+def array2pil(a: np.ndarray) -> Image.Image:
     if a.dtype == np.dtype("B"):
         if a.ndim == 2:
             return Image.frombytes("L", (a.shape[1], a.shape[0]),

--- a/kraken/lib/util.py
+++ b/kraken/lib/util.py
@@ -10,13 +10,13 @@ from PIL import Image
 __all__ = ['pil2array', 'array2pil', 'is_bitonal', 'make_printable', 'get_im_str']
 
 
-def pil2array(im: Image.Image, alpha: int = 0) -> np.array:
+def pil2array(im: Image.Image, alpha: int = 0) -> np.ndarray:
     if im.mode == '1':
         return np.array(im.convert('L'))
     return np.array(im)
 
 
-def array2pil(a: np.array) -> Image:
+def array2pil(a: np.ndarray) -> Image:
     if a.dtype == np.dtype("B"):
         if a.ndim == 2:
             return Image.frombytes("L", (a.shape[1], a.shape[0]),

--- a/kraken/pageseg.py
+++ b/kraken/pageseg.py
@@ -46,7 +46,7 @@ class record(object):
         self.__dict__.update(kw)
         self.label = 0  # type: int
         self.bounds = []  # type: List
-        self.mask = None  # type: np.array
+        self.mask = None  # type: np.ndarray
 
 
 def find(condition):
@@ -55,7 +55,7 @@ def find(condition):
     return res
 
 
-def binary_objects(binary: np.array) -> np.array:
+def binary_objects(binary: np.ndarray) -> np.ndarray:
     """
     Labels features in an array and segments them into objects.
     """
@@ -64,7 +64,7 @@ def binary_objects(binary: np.array) -> np.array:
     return objects
 
 
-def estimate_scale(binary: np.array) -> float:
+def estimate_scale(binary: np.ndarray) -> float:
     """
     Estimates image scale based on number of connected components.
     """
@@ -79,9 +79,9 @@ def estimate_scale(binary: np.array) -> float:
     return scale
 
 
-def compute_boxmap(binary: np.array, scale: float,
+def compute_boxmap(binary: np.ndarray, scale: float,
                    threshold: Tuple[float, int] = (.5, 4),
-                   dtype: str = 'i') -> np.array:
+                   dtype: str = 'i') -> np.ndarray:
     """
     Returns grapheme cluster-like boxes based on connected components.
     """
@@ -119,7 +119,7 @@ def compute_lines(segmentation, scale):
     return lines
 
 
-def compute_separators_morph(binary: np.array, scale: float, sepwiden: int = 10, maxcolseps: int = 2) -> np.array:
+def compute_separators_morph(binary: np.ndarray, scale: float, sepwiden: int = 10, maxcolseps: int = 2) -> np.ndarray:
     """Finds vertical black lines corresponding to column separators."""
     logger.debug('Finding vertical black column lines')
     d0 = int(max(5, scale/4))
@@ -132,12 +132,12 @@ def compute_separators_morph(binary: np.array, scale: float, sepwiden: int = 10,
     return vert
 
 
-def compute_colseps_conv(binary: np.array, scale: float = 1.0,
-                         minheight: int = 10, maxcolseps: int = 2) -> np.array:
+def compute_colseps_conv(binary: np.ndarray, scale: float = 1.0,
+                         minheight: int = 10, maxcolseps: int = 2) -> np.ndarray:
     """Find column separators by convolution and thresholding.
 
     Args:
-        binary (numpy.array):
+        binary (numpy.ndarray):
         scale (float):
         minheight (int):
         maxcolseps (int):
@@ -163,12 +163,12 @@ def compute_colseps_conv(binary: np.array, scale: float = 1.0,
     return seps
 
 
-def compute_black_colseps(binary: np.array, scale: float, maxcolseps: int) -> Tuple[np.array, np.array]:
+def compute_black_colseps(binary: np.ndarray, scale: float, maxcolseps: int) -> Tuple[np.ndarray, np.ndarray]:
     """
     Computes column separators from vertical black lines.
 
     Args:
-        binary (numpy.array): Numpy array of the binary image
+        binary (numpy.ndarray): Numpy array of the binary image
         scale (float):
 
     Returns:
@@ -181,12 +181,12 @@ def compute_black_colseps(binary: np.array, scale: float, maxcolseps: int) -> Tu
     return colseps, binary
 
 
-def compute_white_colseps(binary: np.array, scale: float, maxcolseps: int) -> Tuple[np.array, np.array]:
+def compute_white_colseps(binary: np.ndarray, scale: float, maxcolseps: int) -> Tuple[np.ndarray, np.ndarray]:
     """
     Computes column separators either from vertical black lines or whitespace.
 
     Args:
-        binary (numpy.array): Numpy array of the binary image
+        binary (numpy.ndarray): Numpy array of the binary image
         scale (float):
 
     Returns:
@@ -195,19 +195,19 @@ def compute_white_colseps(binary: np.array, scale: float, maxcolseps: int) -> Tu
     return compute_colseps_conv(binary, scale, maxcolseps=maxcolseps)
 
 
-def norm_max(v: np.array) -> np.array:
+def norm_max(v: np.ndarray) -> np.ndarray:
     """
     Normalizes the input array by maximum value.
     """
     return v/np.amax(v)
 
 
-def compute_gradmaps(binary: np.array, scale: float, gauss: bool = False):
+def compute_gradmaps(binary: np.ndarray, scale: float, gauss: bool = False):
     """
     Use gradient filtering to find baselines
 
     Args:
-        binary (numpy.array):
+        binary (numpy.ndarray):
         scale (float):
         gauss (bool): Use gaussian instead of uniform filtering
 
@@ -229,8 +229,8 @@ def compute_gradmaps(binary: np.array, scale: float, gauss: bool = False):
     return bottom, top, boxmap
 
 
-def compute_line_seeds(binary: np.array, bottom: np.array, top: np.array,
-                       colseps: np.array, scale: float, threshold: float = 0.2) -> np.array:
+def compute_line_seeds(binary: np.ndarray, bottom: np.ndarray, top: np.ndarray,
+                       colseps: np.ndarray, scale: float, threshold: float = 0.2) -> np.ndarray:
     """
     Base on gradient maps, computes candidates for baselines and xheights.
     Then, it marks the regions between the two as a line seed.
@@ -263,17 +263,17 @@ def compute_line_seeds(binary: np.array, bottom: np.array, top: np.array,
     return seeds
 
 
-def remove_hlines(binary: np.array, scale: float, maxsize: int = 10) -> np.array:
+def remove_hlines(binary: np.ndarray, scale: float, maxsize: int = 10) -> np.ndarray:
     """
     Removes horizontal black lines that only interfere with page segmentation.
 
         Args:
-            binary (numpy.array):
+            binary (numpy.ndarray):
             scale (float):
             maxsize (int): maximum size of removed lines
 
         Returns:
-            numpy.array containing the filtered image.
+            numpy.ndarray containing the filtered image.
 
     """
     logger.debug('Filtering horizontal lines')
@@ -285,7 +285,7 @@ def remove_hlines(binary: np.array, scale: float, maxsize: int = 10) -> np.array
     return np.array(labels != 0, 'B')
 
 
-def rotate_lines(lines: np.array, angle: float, offset: int) -> np.array:
+def rotate_lines(lines: np.ndarray, angle: float, offset: int) -> np.ndarray:
     """
     Rotates line bounding boxes around the origin and adding and offset.
     """
@@ -306,7 +306,7 @@ def segment(im, text_direction: str = 'horizontal-lr',
             black_colseps: bool = False,
             no_hlines: bool = True,
             pad: int = 0,
-            mask: Optional[np.array] = None,
+            mask: Optional[np.ndarray] = None,
             reading_order_fn: Callable = reading_order) -> Dict[str, Any]:
     """
     Segments a page into text lines.

--- a/kraken/pageseg.py
+++ b/kraken/pageseg.py
@@ -97,7 +97,7 @@ def compute_boxmap(binary: np.ndarray, scale: float,
     return boxmap
 
 
-def compute_lines(segmentation, scale):
+def compute_lines(segmentation: np.ndarray, scale: float) -> List[record]:
     """Given a line segmentation map, computes a list
     of tuples consisting of 2D slices and masked images."""
     logger.debug('Convert segmentation to lines')

--- a/tests/test_readingorder.py
+++ b/tests/test_readingorder.py
@@ -15,7 +15,7 @@ thisfile = os.path.abspath(os.path.dirname(__file__))
 resources = os.path.abspath(os.path.join(thisfile, 'resources'))
 
 
-def polygon_slices(polygon: Sequence) -> Tuple:
+def polygon_slices(polygon: Sequence[Tuple[int, int]]) -> Tuple[slice, slice]:
     """Convert polygons to slices for reading_order"""
     linestr = geom.LineString(polygon)
     slices = (slice(linestr.bounds[1], linestr.bounds[0]),
@@ -40,8 +40,8 @@ class TestReadingOrder(unittest.TestCase):
         """
         A real baseline should be in its polygonization.
         """
-        line = geom.LineString([(268,656), (888,656)])
-        polygon = geom.Polygon([(268,656), (265,613), (885,611), (888,656), (885,675), (265,672)])
+        line = geom.LineString([(268, 656), (888, 656)])
+        polygon = geom.Polygon([(268, 656), (265, 613), (885, 611), (888, 656), (885, 675), (265, 672)])
         self.assertTrue(is_in_region(line, polygon))
     
     def test_is_in_region3(self):
@@ -125,6 +125,38 @@ class TestReadingOrder(unittest.TestCase):
         expected = np.array([[0, 1], [0, 0]])
         self.assertTrue(np.array_equal(order, expected), "Reading order is not as expected: {}".format(order))
 
+    def test_order_simple_right_left(self):
+        """
+        Two lines (as their polygonal boundaries) are in reverse RTL-order.
+        In this example, the boundaries are rectangles that align horizontally,
+        have horizontal base lines and do not overlap or touch::
+
+            BBBB  AAAA
+        
+        """
+        polygon0 = [[10, 10], [10, 20], [100, 20], [100, 10], [10, 10]]
+        polygon1 = [[150, 10], [150, 20], [250, 20], [250, 10], [150, 10]]
+        order = reading_order([polygon_slices(line) for line in [polygon0, polygon1]], 'rl')
+        # line1 should come before line0, lines do not come before themselves
+        expected = np.array([[0, 0], [1, 0]])
+        self.assertTrue(np.array_equal(order, expected), "Reading order is not as expected: {}".format(order))
+
+    def test_order_simple_right_left_touching(self):
+        """
+        Two lines (as their polygonal boundaries) are in reverse RTL-order.
+        In this example, the boundaries are rectangles that align horizontally,
+        have horizontal base lines and touch::
+
+            BBBBAAAA
+        
+        """
+        polygon0 = [[10, 10], [10, 20], [100, 20], [100, 10], [10, 10]]
+        polygon1 = [[100, 10], [100, 20], [250, 20], [250, 10], [100, 10]]
+        order = reading_order([polygon_slices(line) for line in [polygon0, polygon1]])
+        # line1 should come before line0, lines do not come before themselves
+        expected = np.array([[0, 0], [1, 0]])
+        self.assertTrue(np.array_equal(order, expected), "Reading order is not as expected: {}".format(order))
+
     def test_order_real_reverse(self):
         """
         Real example: lines are in reverse order.
@@ -157,30 +189,30 @@ class TestReadingOrder(unittest.TestCase):
         """
         Return list for three lines that are already in order.
         """
-        partial_sort = np.array([[1,1,1], [0,1,1], [0,0,1]])
-        expected = [0,1,2]
+        partial_sort = np.array([[1, 1, 1], [0, 1, 1], [0, 0, 1]])
+        expected = [0, 1, 2]
         self.assertTrue(np.array_equal(topsort(partial_sort), expected))
 
     def test_topsort_ordered_no_self(self):
         """
         Return list for three lines that are already in order.
         """
-        partial_sort = np.array([[0,1,1], [0,0,1], [0,0,0]])
-        expected = [0,1,2]
+        partial_sort = np.array([[0, 1, 1], [0, 0, 1], [0, 0, 0]])
+        expected = [0, 1, 2]
         self.assertTrue(np.array_equal(topsort(partial_sort), expected))
 
     def test_topsort_unordered(self):
         """
         Return list for three lines that are partially in order.
         """
-        partial_sort = np.array([[1,1,1], [0,1,0], [0,1,1]])
-        expected = [0,2,1]
+        partial_sort = np.array([[1, 1, 1], [0, 1, 0], [0, 1, 1]])
+        expected = [0, 2, 1]
         self.assertTrue(np.array_equal(topsort(partial_sort), expected))
 
     def test_topsort_unordered_no_self(self):
         """
         Return list for three lines that are partially in order.
         """
-        partial_sort = np.array([[0,1,1], [0,0,0], [0,1,0]])
-        expected = [0,2,1]
+        partial_sort = np.array([[0, 1, 1], [0, 0, 0], [0, 1, 0]])
+        expected = [0, 2, 1]
         self.assertTrue(np.array_equal(topsort(partial_sort), expected))


### PR DESCRIPTION
In an effort to find the cause of #278 and earlier issues, I added two more small tests for the right-to-left reading order. They are basically the inverse of the left-to-right tests (and also fail in the same way).

I also tried to have automated checks of function inputs and outputs based on existing type annotations. Many packages that kraken depends on do not provide type annotations, so `mypy` produces lots of errors when it skips analysing certain files. Based on mypy and visual analysis of code and docstrings, this PR:

- corrects some typing (e.g. `np.array` (the function) -> `np.ndarray` (the type))
- adds some typing annotations (e.g. a return value)
- makes some typing annotations more specific (e.g. `List[int]` instead of `List`)

Based on warnings produced by Numpy 1.21 when running tests, this PR also replaces `dtype`s in numpy calls that are deprecated in numpy 1.20 (`np.int|np.bool|np.float` become `int|bool|float`).

Apologies for the large pull request.