### PR TITLE
Output TextEquiv for Word and TextLine too

### DIFF
--- a/kraken/templates/pagexml
+++ b/kraken/templates/pagexml
@@ -19,8 +19,10 @@
 						<TextEquiv conf="{{ char.confidence|round(4) }}"><Unicode>{{ char.text|e }}</Unicode></TextEquiv>
 					</Glyph>
 				{% endfor %}
+					<TextEquiv conf="{{ (segment.confidences|sum / segment.confidences|length)|round(4) }}"><Unicode>{{ segment.text|e }}</Unicode></TextEquiv>
 				</Word>
 				{% endfor %}
+				{% if line.confidences|length %}<TextEquiv conf="{{ (line.confidences|sum / line.confidences|length)|round(4) }}"><Unicode>{% for segment in line.recognition %}{{ segment.text|e }}{% endfor %}</Unicode></TextEquiv>{% endif %}
 			</TextLine>
 {% endmacro %}
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
This change adds `<TextEquiv>` elements at the end of `<Word>` and `<TextLine>` elements, inspired by how the ALTO template has the text for each word as an attribute. I wanted this to make preparing PageXML training data easier, because the documentation says kraken only considers the `<TextEquiv>` elements for training when they are direct childs of `<TextLine>`.

In rare cases I found there are no `confidences` for a line, which resulted in exceptions during the templating. Hence the conditional.