### PR TITLE
Remove legacy line

### DIFF
--- a/kraken/lib/dataset.py
+++ b/kraken/lib/dataset.py
@@ -505,7 +505,7 @@ class PolygonGTDataset(Dataset):
                 im = self.tail_transforms(im)
             except ValueError:
                 raise KrakenInputException(f'Image transforms failed on {image}')
-            self._images.append(im)
+            
             return {'text': text,
                     'image': im,
                     'baseline': baseline,


### PR DESCRIPTION
Duplicate line causing image-label misalignment.

During `PolygonGTDataset` creation using the method `add()`, which itself calls `parse()`, images get added twice to `self._images` while labels get added only once to `self._gt`. This causes misalignment between images and labels. 

The [following line in PolygonGTDataset.parse()](https://github.com/mittagessen/kraken/blob/972ae6cf06b7a6e4323b81ae81ad300c816e6b94/kraken/lib/dataset.py#L508), which should have been removed in [that commit](https://github.com/mittagessen/kraken/commit/9bcdecb814b2873747c03b62e1488fa37f305d1f) is to blame:

    self._images.append(im)

since it is performed (again) in [add()](https://github.com/mittagessen/kraken/blob/972ae6cf06b7a6e4323b81ae81ad300c816e6b94/kraken/lib/dataset.py#L462)

    self._images.append(kwargs['image']

The most obvious symptom is the validation metric computation during training when loading and existing model. This also sometimes causes the metric to be negative. Indirectly this also breaks training.

Closes #288