### PR TITLE
Drop short option form -p for --pad in all ketos commands

### DIFF
--- a/docs/ketos.rst
+++ b/docs/ketos.rst
@@ -60,7 +60,7 @@ both from scratch and from existing models. Here are its command line options:
 ======================================================= ======
 option                                                  action
 ======================================================= ======
--p, --pad                                               Left and right padding around lines
+--pad                                                   Left and right padding around lines
 -o, --output                                            Output model file prefix. Defaults to model.
 -s, --spec                                              VGSL spec of the network to train. CTC layer
                                                         will be added automatically. default:
@@ -271,7 +271,7 @@ option                                                  action
 -m, --model                                             Model(s) to evaluate.
 -e, --evaluation-files                                  File(s) with paths to evaluation data.
 -d, --device                                            Select device to use.
--p, --pad                                               Left and right padding around lines.
+--pad                                                   Left and right padding around lines.
 
 
 Transcriptions are handed to the command in the same way as for the `train`

--- a/kraken/ketos.py
+++ b/kraken/ketos.py
@@ -361,7 +361,7 @@ def segtrain(ctx, output, spec, line_width, load, freq, quit, epochs,
 @click.pass_context
 @click.option('-B', '--batch-size', show_default=True, type=click.INT,
               default=RECOGNITION_HYPER_PARAMS['batch_size'], help='batch sample size')
-@click.option('-p', '--pad', show_default=True, type=click.INT, default=16, help='Left and right '
+@click.option('--pad', show_default=True, type=click.INT, default=16, help='Left and right '
               'padding around lines')
 @click.option('-o', '--output', show_default=True, type=click.Path(), default='model', help='Output model file')
 @click.option('-s', '--spec', show_default=True, default=RECOGNITION_SPEC,
@@ -617,7 +617,7 @@ def train(ctx, batch_size, pad, output, spec, append, load, freq, quit, epochs,
               callback=_validate_manifests, type=click.File(mode='r', lazy=True),
               help='File(s) with paths to evaluation data.')
 @click.option('-d', '--device', show_default=True, default='cpu', help='Select device to use (cpu, cuda:0, cuda:1, ...)')
-@click.option('-p', '--pad', show_default=True, type=click.INT, default=16, help='Left and right '
+@click.option('--pad', show_default=True, type=click.INT, default=16, help='Left and right '
               'padding around lines')
 @click.option('--threads', show_default=True, default=1, help='Number of OpenMP threads when running on CPU.')
 @click.option('--reorder/--no-reorder', show_default=True, default=True, help='Reordering of code points to display order')


### PR DESCRIPTION
It was already removed for `ketos transcribe` (see issue #180),
but still existed in `ketos train` and `ketos segtrain` where
it is also used for `--partition`.

Signed-off-by: Stefan Weil <sw@weilnetz.de>