### PR TITLE
Log partial reading order at debug level

### DIFF
--- a/kraken/lib/segmentation.py
+++ b/kraken/lib/segmentation.py
@@ -105,7 +105,7 @@ def reading_order(lines: Sequence[Tuple[slice, slice]], text_direction: str = 'l
             else:
                 if [w for w in lines if _separates(w, u, v)] == []:
                     if horizontal_order(u, v):
-                        print(f'{u} - {v}')
+                        logger.debug(f'{u} - {v}')
                         order[i, j] = 1
     return order
 


### PR DESCRIPTION
Instead of `print`ing debug information, use `logger.debug`