### PR TITLE
CustomPageXML parsing: allow ":" in value

### DIFF
--- a/kraken/lib/xml.py
+++ b/kraken/lib/xml.py
@@ -106,8 +106,8 @@ def parse_page(filename):
                 tag_vals = {}
                 vals = [val.strip() for val in vals.split(';') if val.strip()]
                 for val in vals:
-                    key, val = val.split(':')
-                    tag_vals[key] = val
+                    key, *val = val.split(':')
+                    tag_vals[key] = ":".join(val)
                 o[tag.strip()] = tag_vals
         return o
 


### PR DESCRIPTION
In situation where Regions have `:`, this would yield an error, such as the Segmonto syntax:

```xml
<TextRegion id="region_1601885451429_143"  custom="structure {type:NumberingZone:page;}">
```
This fixes this CustomPAGE way to parse the properties.