### PR TITLE
Provide timestamp as explicit UTC

### DIFF
--- a/kraken/serialization.py
+++ b/kraken/serialization.py
@@ -109,7 +109,7 @@ def serialize(records: Sequence[ocr_record],
             'name': image_name,
             'writing_mode': writing_mode,
             'scripts': scripts,
-            'date': datetime.datetime.now().isoformat(),
+            'date': datetime.datetime.utcnow().isoformat() + 'Z',
             'base_dir': [rec.base_dir for rec in records][0] if len(records) else None}  # type: dict
     seg_idx = 0
     char_idx = 0

--- a/kraken/serialization.py
+++ b/kraken/serialization.py
@@ -109,7 +109,7 @@ def serialize(records: Sequence[ocr_record],
             'name': image_name,
             'writing_mode': writing_mode,
             'scripts': scripts,
-            'date': datetime.datetime.utcnow().isoformat() + 'Z',
+            'date': datetime.datetime.now(datetime.timezone.utc).isoformat(),
             'base_dir': [rec.base_dir for rec in records][0] if len(records) else None}  # type: dict
     seg_idx = 0
     char_idx = 0


### PR DESCRIPTION
The `+ 'Z'` part doesn't look very pretty, but this change provides the UTC timestamp as a string that explicitly shows it's a UTC timestamp. This fixes #327.