### PR TITLE
Add utility function serialization.serialize_segmentation

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -19,3 +19,6 @@ div.rightside {
     margin-left: 125px;
 }
 
+dl.py {
+    margin-top: 25px;
+}

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -99,6 +99,7 @@ Afterwards they can be fed into the segmentation method
 .. code-block:: python
 
         >>> from kraken import blla
+        >>> from kraken import serialization
 
         >>> baseline_seg = blla.segment(im, model=model)
         >>> baseline_seg
@@ -112,6 +113,9 @@ Afterwards they can be fed into the segmentation method
          'regions': {'$tip':[[[536, 1716], ... [522, 1708], [524, 1716], [536, 1716], ...]
                      '$par': ...
                      '$nop':  ...}}
+        >>> alto = serialization.serialize_segmentation(baseline_seg, image_name=im.filename, image_size=im.size, template='alto')
+        >>> with open('segmentation_output.xml', 'w') as fp:
+                fp.write(alto)
 
 Optional parameters are largely the same as for the legacy segmenter, i.e. text
 direction and masking.

--- a/docs/api_docs.rst
+++ b/docs/api_docs.rst
@@ -45,6 +45,8 @@ kraken.serialization module
 
 .. autoapifunction:: kraken.serialization.serialize
 
+.. autoapifunction:: kraken.serialization.serialize_segmentation
+
 kraken.lib.models module
 ========================
 

--- a/kraken/kraken.py
+++ b/kraken/kraken.py
@@ -161,19 +161,10 @@ def segmenter(legacy, model, text_direction, scale, maxcolseps, black_colseps,
             logger.info('Serializing as {} into {}'.format(ctx.meta['output_mode'], output))
             from kraken import serialization
             from kraken.rpred import ocr_record
-            if 'type' in res and res['type'] == 'baselines':
-                records = [ocr_record('', '', '', bl) for bl in res['lines']]
-            else:
-                records = []
-                for line in res['boxes']:
-                    xmin, xmax = min(line[::2]), max(line[::2])
-                    ymin, ymax = min(line[1::2]), max(line[1::2])
-                    records.append(ocr_record('', [], [], [[xmin, ymin], [xmin, ymax], [xmax, ymax], [xmax, ymin]]))
-            fp.write(serialization.serialize(records,
-                                             image_name=ctx.meta['base_image'],
-                                             image_size=im.size,
-                                             regions=res['regions'] if 'regions' in res else None,
-                                             template=ctx.meta['output_mode']))
+            fp.write(serialization.serialize_segmentation(res,
+                                                          image_name=ctx.meta['base_image'],
+                                                          image_size=im.size,
+                                                          template=ctx.meta['output_mode']))
     else:
         with click.open_file(output, 'w') as fp:
             fp = cast(IO[Any], fp)

--- a/kraken/serialization.py
+++ b/kraken/serialization.py
@@ -27,7 +27,7 @@ from kraken.rpred import ocr_record
 from kraken.lib.util import make_printable
 from kraken.lib.segmentation import is_in_region
 
-from typing import List, Tuple, Iterable, Optional, Sequence, Dict
+from typing import List, Tuple, Iterable, Optional, Sequence, Dict, Any
 
 logger = logging.getLogger(__name__)
 
@@ -233,6 +233,38 @@ def serialize(records: Sequence[ocr_record],
     tmpl = env.get_template(template)
     logger.debug('Rendering data.')
     return tmpl.render(page=page)
+
+
+def serialize_segmentation(res: Dict[str, Any],
+                           image_name: str = None,
+                           image_size: Tuple[int, int] = (0, 0),
+                           template: str = 'hocr') -> str:
+    """
+    Serializes a segmentation result into an output document.
+
+    Args:
+        res: Result of blla.segment
+        image_name (str): Name of the source image
+        image_size (tuple): Dimensions of the source image
+        template (str): Selector for the serialization format. May be
+                        'hocr' or 'alto'.
+
+    Returns:
+            (str) rendered template.
+    """
+    if 'type' in res and res['type'] == 'baselines':
+        records = [ocr_record('', '', '', bl) for bl in res['lines']]
+    else:
+        records = []
+        for line in res['boxes']:
+            xmin, xmax = min(line[::2]), max(line[::2])
+            ymin, ymax = min(line[1::2]), max(line[1::2])
+            records.append(ocr_record('', [], [], [[xmin, ymin], [xmin, ymax], [xmax, ymax], [xmax, ymin]]))
+    return serialize(records,
+                     image_name=image_name,
+                     image_size=image_size,
+                     regions=res['regions'] if 'regions' in res else None,
+                     template=template)
 
 
 def render_report(model: str,

--- a/kraken/serialization.py
+++ b/kraken/serialization.py
@@ -235,7 +235,7 @@ def serialize(records: Sequence[ocr_record],
     return tmpl.render(page=page)
 
 
-def serialize_segmentation(res: Dict[str, Any],
+def serialize_segmentation(segresult: Dict[str, Any],
                            image_name: str = None,
                            image_size: Tuple[int, int] = (0, 0),
                            template: str = 'hocr') -> str:
@@ -243,7 +243,7 @@ def serialize_segmentation(res: Dict[str, Any],
     Serializes a segmentation result into an output document.
 
     Args:
-        res: Result of blla.segment
+        segresult: Result of blla.segment
         image_name (str): Name of the source image
         image_size (tuple): Dimensions of the source image
         template (str): Selector for the serialization format. May be
@@ -252,18 +252,18 @@ def serialize_segmentation(res: Dict[str, Any],
     Returns:
             (str) rendered template.
     """
-    if 'type' in res and res['type'] == 'baselines':
-        records = [ocr_record('', '', '', bl) for bl in res['lines']]
+    if 'type' in segresult and segresult['type'] == 'baselines':
+        records = [ocr_record('', '', '', bl) for bl in segresult['lines']]
     else:
         records = []
-        for line in res['boxes']:
+        for line in segresult['boxes']:
             xmin, xmax = min(line[::2]), max(line[::2])
             ymin, ymax = min(line[1::2]), max(line[1::2])
             records.append(ocr_record('', [], [], [[xmin, ymin], [xmin, ymax], [xmax, ymax], [xmax, ymin]]))
     return serialize(records,
                      image_name=image_name,
                      image_size=image_size,
-                     regions=res['regions'] if 'regions' in res else None,
+                     regions=segresult['regions'] if 'regions' in segresult else None,
                      template=template)
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths =
+    tests

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -220,3 +220,12 @@ class TestSerializations(unittest.TestCase):
 
         fp.write(serialization.serialize([], image_name='foo.png', template='pagexml', regions=self.bl_regions))
         validate_page(self, fp)
+
+    def test_serialize_segementation_alto(self):
+        """
+        Validates output of `serialize_segmentation` against ALTO schema
+        """
+        fp = StringIO()
+
+        fp.write(serialization.serialize_segmentation({'boxes': []}, image_name='foo.png', template='alto'))
+        validate_alto(self, fp)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -48,7 +48,8 @@ def validate_page(self, fp):
 
     ids = [x.get('id') for x in doc.findall('.//*[@id]')]
     counts = Counter(ids)
-    self.assertEqual(counts.most_common(1)[0][1], 1, msg='Duplicate IDs in PageXML output')
+    if len(counts):
+        self.assertEqual(counts.most_common(1)[0][1], 1, msg='Duplicate IDs in PageXML output')
 
     with open(resources / 'pagecontent.xsd') as schema_fp:
         page_schema = etree.XMLSchema(etree.parse(schema_fp))
@@ -221,7 +222,7 @@ class TestSerializations(unittest.TestCase):
         fp.write(serialization.serialize([], image_name='foo.png', template='pagexml', regions=self.bl_regions))
         validate_page(self, fp)
 
-    def test_serialize_segementation_alto(self):
+    def test_serialize_segmentation_alto(self):
         """
         Validates output of `serialize_segmentation` against ALTO schema
         """
@@ -229,3 +230,12 @@ class TestSerializations(unittest.TestCase):
 
         fp.write(serialization.serialize_segmentation({'boxes': []}, image_name='foo.png', template='alto'))
         validate_alto(self, fp)
+
+    def test_serialize_segmentation_pagexml(self):
+        """
+        Validates output of `serialize_segmentation` against ALTO schema
+        """
+        fp = StringIO()
+
+        fp.write(serialization.serialize_segmentation({'boxes': []}, image_name='foo.png', template='pagexml'))
+        validate_page(self, fp)


### PR DESCRIPTION
## Description

* Adds a function `serialize_segmentation` to save the result of `blla.segment` to e.g. ALTO XML
* Add an example usage of this function in the "API Quickstart", and the reference to the API reference
* Add a test for this new function 
* Make use of it in `kraken segmenter`

## Demo

```python

# load a segmentation model

with PIL.Image.open('foo.jpg') as im:
    res = blla.segment(im, model=model)
    size = im.size
with open('foo.xml', 'w') as fp:
    fp.write(serialization.serialize_segmentation(res, 'foo.jpg', size, template='alto'))
```