### PR TITLE
initial proof of concept page gen

### DIFF
--- a/kraken/ketos.py
+++ b/kraken/ketos.py
@@ -1068,34 +1068,33 @@ def pagegen(ctx, font, encoding, font_size, font_weight, language, output, text)
         
         return tmpl.render(page=page)
 
-    merged_text = ''
-    for t in text:
+
+    for it, t in enumerate(text):
         with click.open_file(t, encoding=encoding) as fp:
             logger.info('Reading {}'.format(t))
-            merged_text += fp.read()
+            text_ = fp.read()
     
-    lg = linegen.PageGenerator(font, font_size, font_weight, language)
+        lg = linegen.PageGenerator(font, font_size, font_weight, language, encoding)
 
-    im, regions = lg.render(merged_text)
+        im, regions = lg.render(text_)
 
-    base_fn = "{0:08d}".format(0)
-    image_fp = Path(output) / (base_fn + '.png')
+        base_fn = "{0:08d}".format(it)
+        image_fp = Path(output) / (base_fn + '.png')
 
-    alto_str = serialize(
-        regions=regions,
-        image_name=image_fp.name,
-        image_size=im.size,
-        writing_mode="horizontal-lr",
-        base_dir=output
-    )
-    
-    
-    alto_fp = Path(output) / (base_fn + '.xml')
+        alto_str = serialize(
+            regions=regions,
+            image_name=image_fp.name,
+            image_size=im.size,
+            writing_mode="horizontal-lr",
+            base_dir=output
+        )
+        
+        alto_fp = Path(output) / (base_fn + '.xml')
 
-    with open(alto_fp, 'w') as fp:
-        fp.write(alto_str)
-    
-    im.save(image_fp)
+        with open(alto_fp, 'w') as fp:
+            fp.write(alto_str)
+        
+        im.save(image_fp)
 
 
 @cli.command('linegen')

--- a/kraken/serialization.py
+++ b/kraken/serialization.py
@@ -164,49 +164,53 @@ def serialize(records: Sequence[ocr_record],
             line['tags'] = record.tags
         if record.type == 'baselines':
             line['baseline'] = [list(x) for x in record.baseline]
-        splits = regex.split(r'(\s+)', record.prediction)
-        line_offset = 0
-        logger.debug(f'Record contains {len(splits)} segments')
-        for segment in splits:
-            if len(segment) == 0:
-                continue
-            seg_bbox = max_bbox(record.cuts[line_offset:line_offset + len(segment)])
-            seg_struct = {'bbox': seg_bbox,
-                          'confidences': record.confidences[line_offset:line_offset + len(segment)],
-                          'cuts': record.cuts[line_offset:line_offset + len(segment)],
-                          'text': segment,
-                          'recognition': [{'bbox': max_bbox([cut]),
-                                           'boundary': cut,
-                                           'confidence': conf,
-                                           'text': char,
-                                           'index': cid}
-                                          for conf, cut, char, cid in
-                                          zip(record.confidences[line_offset:line_offset + len(segment)],
-                                              record.cuts[line_offset:line_offset + len(segment)],
-                                              segment,
-                                              range(char_idx, char_idx + len(segment)))],
-                          'index': seg_idx}
-            # compute convex hull of all characters in segment
-            if record.type == 'baselines':
-                pols = []
-                for x in record.cuts[line_offset:line_offset + len(segment)]:
-                    try:
-                        pol = geom.Polygon(x)
-                    except ValueError:
-                        pol = geom.LineString(x).buffer(0.5, cap_style=2)
-                    if pol.area == 0.0:
-                        pol = pol.buffer(0.5)
-                    # if area is still 0 it's probably a point
-                    if pol.area == 0.0:
-                        pol = geom.Point(x[0]).buffer(0.5)
-                    pols.append(pol)
-                pols = unary_union(pols)
-                coords = np.array(pols.convex_hull.exterior.coords, dtype=np.uint).tolist()
-                seg_struct['boundary'] = coords
-            line['recognition'].append(seg_struct)
-            char_idx += len(segment)
-            seg_idx += 1
-            line_offset += len(segment)
+
+        if len(record.cuts) == 0:
+            line['recognition'] = record.prediction
+        else: 
+            splits = regex.split(r'(\s+)', record.prediction)
+            line_offset = 0
+            logger.debug(f'Record contains {len(splits)} segments')
+            for segment in splits:
+                if len(segment) == 0:
+                    continue
+                seg_bbox = max_bbox(record.cuts[line_offset:line_offset + len(segment)])
+                seg_struct = {'bbox': seg_bbox,
+                            'confidences': record.confidences[line_offset:line_offset + len(segment)],
+                            'cuts': record.cuts[line_offset:line_offset + len(segment)],
+                            'text': segment,
+                            'recognition': [{'bbox': max_bbox([cut]),
+                                            'boundary': cut,
+                                            'confidence': conf,
+                                            'text': char,
+                                            'index': cid}
+                                            for conf, cut, char, cid in
+                                            zip(record.confidences[line_offset:line_offset + len(segment)],
+                                                record.cuts[line_offset:line_offset + len(segment)],
+                                                segment,
+                                                range(char_idx, char_idx + len(segment)))],
+                            'index': seg_idx}
+                # compute convex hull of all characters in segment
+                if record.type == 'baselines':
+                    pols = []
+                    for x in record.cuts[line_offset:line_offset + len(segment)]:
+                        try:
+                            pol = geom.Polygon(x)
+                        except ValueError:
+                            pol = geom.LineString(x).buffer(0.5, cap_style=2)
+                        if pol.area == 0.0:
+                            pol = pol.buffer(0.5)
+                        # if area is still 0 it's probably a point
+                        if pol.area == 0.0:
+                            pol = geom.Point(x[0]).buffer(0.5)
+                        pols.append(pol)
+                    pols = unary_union(pols)
+                    coords = np.array(pols.convex_hull.exterior.coords, dtype=np.uint).tolist()
+                    seg_struct['boundary'] = coords
+                line['recognition'].append(seg_struct)
+                char_idx += len(segment)
+                seg_idx += 1
+                line_offset += len(segment)
         cur_ent.append(line)
 
     # No records but there are regions -> serialize all regions

--- a/kraken/templates/alto
+++ b/kraken/templates/alto
@@ -19,48 +19,52 @@
 			<Polygon POINTS="{{ line.boundary|sum(start=[])|join(' ') }}"/>
 		</Shape>
 	{% endif %}
-        {% if line.recognition|length() == 0 %}
+    {% if line.recognition|length() == 0 %}
 		<String CONTENT=""/>
 	{% else %}
-	{% for segment in line.recognition %}
-		{# ALTO forbids encoding whitespace before any String/Shape tags #}
-		{% if segment.text is whitespace and loop.index > 1 %}
-		<SP ID="segment_{{ segment.index }}"
-		    HPOS="{{ segment.bbox[0]}}" 
-		    VPOS="{{ segment.bbox[1] }}"
-		    WIDTH="{{ segment.bbox[2] - segment.bbox[0] }}" 
-		    HEIGHT="{{ segment.bbox[3] - segment.bbox[1] }}"/>
+		{% if line.cuts|length() == 0 %}
+			<String CONTENT="{{ line.recognition }}"/>
 		{% else %}
-		<String ID="segment_{{ segment.index }}"
-			CONTENT="{{ segment.text|e }}" 
-			HPOS="{{ segment.bbox[0] }}" 
-			VPOS="{{ segment.bbox[1] }}"
-			WIDTH="{{ segment.bbox[2] - segment.bbox[0] }}" 
-			HEIGHT="{{ segment.bbox[3] - segment.bbox[1] }}" 
-			WC="{{ (segment.confidences|sum / segment.confidences|length)|round(4) }}">
-			{% if segment.boundary %}
-			<Shape>
-				<Polygon POINTS="{{ segment.boundary|sum(start=[])|join(' ') }}"/>
-			</Shape>
-			{% endif %}
-			{% for char in segment.recognition %}
-			<Glyph ID="char_{{ char.index }}" 
-			       CONTENT="{{ char.text|e }}"
-			       HPOS="{{ char.bbox[0] }}"
-			       VPOS="{{ char.bbox[1] }}"
-			       WIDTH="{{ char.bbox[2] - char.bbox[0] }}"
-			       HEIGHT="{{ char.bbox[3] - char.bbox[1] }}"
-			       GC="{{ char.confidence|round(4) }}">
-			{% if char.boundary %}
-			<Shape>
-				<Polygon POINTS="{{ char.boundary|sum(start=[])|join(' ') }}"/>
-			</Shape>
-			{% endif %}
-			</Glyph>
+			{% for segment in line.recognition %}
+				{# ALTO forbids encoding whitespace before any String/Shape tags #}
+				{% if segment.text is whitespace and loop.index > 1 %}
+				<SP ID="segment_{{ segment.index }}"
+					HPOS="{{ segment.bbox[0]}}" 
+					VPOS="{{ segment.bbox[1] }}"
+					WIDTH="{{ segment.bbox[2] - segment.bbox[0] }}" 
+					HEIGHT="{{ segment.bbox[3] - segment.bbox[1] }}"/>
+				{% else %}
+				<String ID="segment_{{ segment.index }}"
+					CONTENT="{{ segment.text|e }}" 
+					HPOS="{{ segment.bbox[0] }}" 
+					VPOS="{{ segment.bbox[1] }}"
+					WIDTH="{{ segment.bbox[2] - segment.bbox[0] }}" 
+					HEIGHT="{{ segment.bbox[3] - segment.bbox[1] }}" 
+					WC="{{ (segment.confidences|sum / segment.confidences|length)|round(4) }}">
+					{% if segment.boundary %}
+					<Shape>
+						<Polygon POINTS="{{ segment.boundary|sum(start=[])|join(' ') }}"/>
+					</Shape>
+					{% endif %}
+					{% for char in segment.recognition %}
+					<Glyph ID="char_{{ char.index }}" 
+						CONTENT="{{ char.text|e }}"
+						HPOS="{{ char.bbox[0] }}"
+						VPOS="{{ char.bbox[1] }}"
+						WIDTH="{{ char.bbox[2] - char.bbox[0] }}"
+						HEIGHT="{{ char.bbox[3] - char.bbox[1] }}"
+						GC="{{ char.confidence|round(4) }}">
+					{% if char.boundary %}
+					<Shape>
+						<Polygon POINTS="{{ char.boundary|sum(start=[])|join(' ') }}"/>
+					</Shape>
+					{% endif %}
+					</Glyph>
+					{% endfor %}
+				</String>
+				{% endif %}
 			{% endfor %}
-		</String>
 		{% endif %}
-	{% endfor %}
 	{% endif %}
 </TextLine>
 {%- endmacro %}


### PR DESCRIPTION
This pull request ist at the moment just to synchronize the discussion on how to proceed. 
It introduces a new CLI command, `ketos pagegen` that
takes as input
* a plain text 
and that outputs
* a png file
* an alto.xml file

into a directory, so that one can immediately run 

`ketos train -f xml outdir/*.xml`


in order to test it:

1. create a file `sample.txt` with the following contents:

```
this is a first line.
and this is a second one.
```

2. create the output directory `outdir`
3. run `ketos pagegen -o outdir sample.txt`
4. run `ketos train -f xml outdir/*.xml`