### PR TITLE
Rebuild Arrow alphabet if the normalization is set.

### DIFF
--- a/kraken/lib/train.py
+++ b/kraken/lib/train.py
@@ -336,6 +336,9 @@ class RecognitionModel(pl.LightningModule):
                     dataset.add(**im)
                 except KrakenInputException as e:
                     logger.warning(str(e))
+            if self.format_type == 'binary' and self.hparams.normalization:
+                logger.debug(f'Rebuilding dataset using unicode normalization')
+                dataset.rebuild_alphabet()
         return dataset
 
     def forward(self, x, seq_lens):


### PR DESCRIPTION
Hey @mittagessen,
This is a simple straightforward fix for #340.
Basically, if ArrowIPCDataset aren't build with the same normalization as the one you want to use at training time, this creates unencodable sequences. By rebuilding the alphabet of the dataset, we overcome this issue.

I extracted the transform function to ensure simplification of maintenance of this bit, as it is now applied in two places.