### PR TITLE
Move nn.codec to False to prevent wrong codec strict mode change

### DIFF
--- a/kraken/lib/train.py
+++ b/kraken/lib/train.py
@@ -497,7 +497,7 @@ class RecognitionModel(pl.LightningModule):
                     else:
                         raise ValueError(f'invalid resize parameter value {self.resize}')
                         
-                codec.strict = False
+                self.nn.codec.strict = False
                 
             else:
                 self.train_set.dataset.encode(self.codec)


### PR DESCRIPTION
Currently, as a followup to #195, there is a situation where the wrong code is changed to strict False