### PR TITLE
Show more informative message for recognition model

### DIFF
--- a/kraken/kraken.py
+++ b/kraken/kraken.py
@@ -580,8 +580,8 @@ def ocr(ctx, model, pad, reorder, base_dir, no_segmentation, text_direction, thr
                 location = loc
                 break
         if not location:
-            raise click.BadParameter(f'No model for {k} found')
-        message(f'Loading ANN {k}\t', nl=False)
+            raise click.BadParameter(f'No model for {v} found')
+        message(f'Loading ANN {v}\t', nl=False)
         try:
             rnn = models.load_any(location, device=ctx.meta['device'])
             nm[k] = rnn


### PR DESCRIPTION
kraken already shows a good message for the segmentation model,
but the corresponding message for the recognition model just
says 'default':

    Loading ANN /home/stweil/src/github/mittagessen/kraken/kraken/blla.mlmodel      ✓
    Loading ANN default     ✓

The new code fixes that:

    Loading ANN /home/stweil/src/github/mittagessen/kraken/kraken/blla.mlmodel	✓
    Loading ANN austriannewspapers.mlmodel	✓

It also fixes the message for the error case (model not found).

Signed-off-by: Stefan Weil <sw@weilnetz.de>