### PR TITLE
Handle ALTO XML with different POINTS representation

### DIFF
--- a/kraken/lib/xml.py
+++ b/kraken/lib/xml.py
@@ -377,7 +377,7 @@ def parse_alto(filename: Union[str, pathlib.Path]) -> Dict[str, Any]:
             # try to find shape object
             coords = region.find('./{*}Shape/{*}Polygon')
             if coords is not None:
-                points = [int(float(x)) for x in coords.get('POINTS').split(' ')]
+                points = [int(float(x)) for x in coords.get('POINTS').replace(',', ' ').split(' ')]
                 boundary = zip(points[::2], points[1::2])
                 boundary = [k for k, g in groupby(boundary)]
             elif (region.get('HPOS') is not None and region.get('VPOS') is not None and
@@ -418,7 +418,7 @@ def parse_alto(filename: Union[str, pathlib.Path]) -> Dict[str, Any]:
             boundary = None
             if pol is not None:
                 try:
-                    points = [int(float(x)) for x in pol.get('POINTS').split(' ')]
+                    points = [int(float(x)) for x in pol.get('POINTS').replace(',', ' ').split(' ')]
                     boundary = zip(points[::2], points[1::2])
                     boundary = [k for k, g in groupby(boundary)]
                 except ValueError:


### PR DESCRIPTION
ALTO XML from ABBYY Finereader separates x and y coordinates with comma:

    <Polygon POINTS="159,837 2414,837 2414,1038 159,1038 159,837"/></Shape>

Replace commas by spaces to support that, too.

Signed-off-by: Stefan Weil <sw@weilnetz.de>