### PR TITLE
Correct alignment bug in repolygonize.py

### DIFF
--- a/kraken/contrib/repolygonize.py
+++ b/kraken/contrib/repolygonize.py
@@ -50,7 +50,7 @@ def cli(format_type, topline, files):
                         pol.attrib['POINTS'] = ' '.join([str(coord) for pt in polygons[idx] for coord in pt])
                     else:
                         pol.attrib['POINTS'] = ''
-                    idx += 1
+                idx += 1
             with open(splitext(fname)[0] + '_rewrite.xml', 'wb') as fp:
                 doc.write(fp, encoding='UTF-8', xml_declaration=True)
 
@@ -80,7 +80,7 @@ def cli(format_type, topline, files):
                         pol.attrib['points'] = ' '.join([','.join([str(x) for x in pt]) for pt in polygons[idx]])
                     else:
                         pol.attrib['points'] = ''
-                    idx += 1
+                idx += 1
             with open(splitext(fname)[0] + '_rewrite.xml', 'wb') as fp:
                 doc.write(fp, encoding='UTF-8', xml_declaration=True)
 


### PR DESCRIPTION
In the `kraken/contrib/repolygonize.py` script, if in one of the lines the `Coords` property (the "boundary") is empty then the variable `idx` is not incremented. This creates a misalignment between baselines and boundaries in the following iterations and thus in the exported file.

Getting the line `idx += 1` out of the condition solves the problem.

(Empty boundaries sometimes happen in files exported from eScriptorium.)