### PR TITLE
make ketos train run again

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ classifier =
 	Programming Language :: Python :: 3.7
 	Programming Language :: Python :: 3.8
 	Programming Language :: Python :: 3.9
+	Programming Language :: Python :: 3.10
 keywords =
     ocr
     htr
@@ -39,7 +40,7 @@ install_requires =
     lxml
     requests
     click>=8.1
-    numpy
+    numpy<=1.23.0
     Pillow>=9.2.0
     regex
     scipy


### PR DESCRIPTION
only a problem since release of numpy 1.24.0 three days ago

("'numpy' has no attribute 'bool'" => apparently it's bool_ now)