### PR TITLE
Remove former development raise in segmentation

### DIFF
--- a/kraken/lib/segmentation.py
+++ b/kraken/lib/segmentation.py
@@ -727,7 +727,6 @@ def calculate_polygonal_environment(im: PIL.Image.Image = None,
                                            im_feats,
                                            bounds))
         except Exception as e:
-            raise
             logger.warning(f'Polygonizer failed on line {idx}: {e}')
             polygons.append(None)
 


### PR DESCRIPTION
This raise seems to have been introduced as you worked on migration ( https://github.com/mittagessen/kraken/commit/90865c2a3266e8da93da5d03bf89e7c8fbce1730 ). This currently breaks segmentation if a single line goes wrong.