### PR TITLE
add --precision option to ketos train and ketos segtrain

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,7 @@ dependencies:
   - imagemagick>=7.1.0
   - coremltools>=6.0
   - pyarrow
-  - conda-forge::pytorch-lightning>=1.7.0
+  - conda-forge::pytorch-lightning>=1.9.0,<2.0
   - conda-forge::torchmetrics>=0.10.0
   - pip
   - albumentations

--- a/environment_cuda.yml
+++ b/environment_cuda.yml
@@ -23,7 +23,7 @@ dependencies:
   - imagemagick>=7.1.0
   - coremltools>=6.0
   - pyarrow
-  - conda-forge::pytorch-lightning>=1.7.0
+  - conda-forge::pytorch-lightning>=1.9.0,<2.0
   - conda-forge::torchmetrics>=0.10.0
   - pip
   - albumentations

--- a/kraken/ketos/pretrain.py
+++ b/kraken/ketos/pretrain.py
@@ -77,6 +77,11 @@ Image.MAX_IMAGE_PIXELS = 20000 ** 2
               type=click.FLOAT,
               help='Minimum improvement between epochs to reset early stopping. Default is scales the delta by the best loss')
 @click.option('-d', '--device', show_default=True, default='cpu', help='Select device to use (cpu, cuda:0, cuda:1, ...)')
+@click.option('--precision',
+                show_default=True, 
+                default='16', 
+                type=click.Choice(['64', '32', 'bf16', '16']),
+                help='Numerical precision to use for training. Default is 16-bit mixed precision.')
 @click.option('--optimizer',
               show_default=True,
               default=RECOGNITION_PRETRAIN_HYPER_PARAMS['optimizer'],
@@ -176,7 +181,7 @@ Image.MAX_IMAGE_PIXELS = 20000 ** 2
               help='Multiplicative factor for the logits used in contrastive loss.')
 @click.argument('ground_truth', nargs=-1, callback=_expand_gt, type=click.Path(exists=False, dir_okay=False))
 def pretrain(ctx, batch_size, pad, output, spec, load, freq, quit, epochs,
-             min_epochs, lag, min_delta, device, optimizer, lrate, momentum,
+             min_epochs, lag, min_delta, device, precision, optimizer, lrate, momentum,
              weight_decay, warmup, schedule, gamma, step_size, sched_patience,
              cos_max, partition, fixed_splits, training_files,
              evaluation_files, workers, load_hyper_parameters, repolygonize,
@@ -271,6 +276,7 @@ def pretrain(ctx, batch_size, pad, output, spec, load, freq, quit, epochs,
 
     trainer = KrakenTrainer(accelerator=accelerator,
                             devices=device,
+                            precision=precision,
                             max_epochs=hyper_params['epochs'] if hyper_params['quit'] == 'dumb' else -1,
                             min_epochs=hyper_params['min_epochs'],
                             enable_progress_bar=True if not ctx.meta['verbose'] else False,

--- a/kraken/ketos/recognition.py
+++ b/kraken/ketos/recognition.py
@@ -78,9 +78,9 @@ logger = logging.getLogger('kraken')
 @click.option('-d', '--device', show_default=True, default='cpu', help='Select device to use (cpu, cuda:0, cuda:1, ...)')
 @click.option('--precision',
                 show_default=True, 
-                default='16-mixed', 
-                type=click.Choice(['32', 'bf16', '16', '16-mixed', 'bf16-mixed']),
-                help='Numerical precision to use for training. Default is 16-mixed precision.')
+                default='16', 
+                type=click.Choice(['64', '32', 'bf16', '16']),
+                help='Numerical precision to use for training. Default is 16-bit mixed precision.')
 @click.option('--optimizer',
               show_default=True,
               default=RECOGNITION_HYPER_PARAMS['optimizer'],

--- a/kraken/ketos/recognition.py
+++ b/kraken/ketos/recognition.py
@@ -76,6 +76,11 @@ logger = logging.getLogger('kraken')
               type=click.FLOAT,
               help='Minimum improvement between epochs to reset early stopping. Default is scales the delta by the best loss')
 @click.option('-d', '--device', show_default=True, default='cpu', help='Select device to use (cpu, cuda:0, cuda:1, ...)')
+@click.option('--precision',
+                show_default=True, 
+                default='16-mixed', 
+                type=click.Choice(['32', 'bf16', '16', '16-mixed', 'bf16-mixed']),
+                help='Numerical precision to use for training. Default is 16-mixed precision.')
 @click.option('--optimizer',
               show_default=True,
               default=RECOGNITION_HYPER_PARAMS['optimizer'],
@@ -181,7 +186,7 @@ logger = logging.getLogger('kraken')
               help='Path to directory where the logger will store the logs. If not set, a directory will be created in the current working directory.')
 @click.argument('ground_truth', nargs=-1, callback=_expand_gt, type=click.Path(exists=False, dir_okay=False))
 def train(ctx, batch_size, pad, output, spec, append, load, freq, quit, epochs,
-          min_epochs, lag, min_delta, device, optimizer, lrate, momentum,
+          min_epochs, lag, min_delta, device, precision, optimizer, lrate, momentum,
           weight_decay, warmup, freeze_backbone, schedule, gamma, step_size,
           sched_patience, cos_max, partition, fixed_splits, normalization,
           normalize_whitespace, codec, resize, reorder, base_dir,
@@ -293,6 +298,7 @@ def train(ctx, batch_size, pad, output, spec, append, load, freq, quit, epochs,
 
     trainer = KrakenTrainer(accelerator=accelerator,
                             devices=device,
+                            precision=precision,
                             max_epochs=hyper_params['epochs'] if hyper_params['quit'] == 'dumb' else -1,
                             min_epochs=hyper_params['min_epochs'],
                             freeze_backbone=hyper_params['freeze_backbone'],

--- a/kraken/ketos/segmentation.py
+++ b/kraken/ketos/segmentation.py
@@ -103,7 +103,6 @@ def _validate_merging(ctx, param, value):
                 default='16-mixed', 
                 type=click.Choice(['32', 'bf16', '16', '16-mixed', 'bf16-mixed']),
                 help='Numerical precision to use for training. Default is 16-mixed precision.')
-@click.option('--precision', default='32', type=click.Choice(['32', '16']), help='set tensor precision')
 @click.option('--optimizer',
               show_default=True,
               default=SEGMENTATION_HYPER_PARAMS['optimizer'],

--- a/kraken/ketos/segmentation.py
+++ b/kraken/ketos/segmentation.py
@@ -100,7 +100,7 @@ def _validate_merging(ctx, param, value):
 @click.option('-d', '--device', show_default=True, default='cpu', help='Select device to use (cpu, cuda:0, cuda:1, ...)')
 @click.option('--precision',
                 show_default=True, 
-                default='16', 
+                default='16',
                 type=click.Choice(['64', '32', 'bf16', '16']),
                 help='Numerical precision to use for training. Default is 16-bit mixed precision.')
 @click.option('--optimizer',

--- a/kraken/ketos/segmentation.py
+++ b/kraken/ketos/segmentation.py
@@ -98,6 +98,11 @@ def _validate_merging(ctx, param, value):
               type=click.FLOAT,
               help='Minimum improvement between epochs to reset early stopping. By default it scales the delta by the best loss')
 @click.option('-d', '--device', show_default=True, default='cpu', help='Select device to use (cpu, cuda:0, cuda:1, ...)')
+@click.option('--precision',
+                show_default=True, 
+                default='16-mixed', 
+                type=click.Choice(['32', 'bf16', '16', '16-mixed', 'bf16-mixed']),
+                help='Numerical precision to use for training. Default is 16-mixed precision.')
 @click.option('--precision', default='32', type=click.Choice(['32', '16']), help='set tensor precision')
 @click.option('--optimizer',
               show_default=True,
@@ -332,6 +337,7 @@ def segtrain(ctx, output, spec, line_width, pad, load, freq, quit, epochs,
 
     trainer = KrakenTrainer(accelerator=accelerator,
                             devices=device,
+                            precision=precision,
                             max_epochs=hyper_params['epochs'] if hyper_params['quit'] == 'dumb' else -1,
                             min_epochs=hyper_params['min_epochs'],
                             enable_progress_bar=True if not ctx.meta['verbose'] else False,

--- a/kraken/ketos/segmentation.py
+++ b/kraken/ketos/segmentation.py
@@ -100,9 +100,9 @@ def _validate_merging(ctx, param, value):
 @click.option('-d', '--device', show_default=True, default='cpu', help='Select device to use (cpu, cuda:0, cuda:1, ...)')
 @click.option('--precision',
                 show_default=True, 
-                default='16-mixed', 
-                type=click.Choice(['32', 'bf16', '16', '16-mixed', 'bf16-mixed']),
-                help='Numerical precision to use for training. Default is 16-mixed precision.')
+                default='16', 
+                type=click.Choice(['64', '32', 'bf16', '16']),
+                help='Numerical precision to use for training. Default is 16-bit mixed precision.')
 @click.option('--optimizer',
               show_default=True,
               default=SEGMENTATION_HYPER_PARAMS['optimizer'],

--- a/kraken/lib/train.py
+++ b/kraken/lib/train.py
@@ -80,7 +80,8 @@ class KrakenTrainer(pl.Trainer):
         if 'mixed' in kwargs['precision']:
             precision = kwargs['precision'].split('-')[0]
             kwargs['precision'] = precision
-            kwargs['plugins'] = [pl.plugins.precision.MixedPrecisionPlugin(precision, 'cuda')]
+            if torch.cuda.is_available():
+                kwargs['plugins'] = [pl.plugins.precision.MixedPrecisionPlugin(precision, 'cuda')]
         kwargs['enable_checkpointing'] = False
         kwargs['enable_progress_bar'] = enable_progress_bar
         kwargs['min_epochs'] = min_epochs

--- a/kraken/lib/train.py
+++ b/kraken/lib/train.py
@@ -77,11 +77,6 @@ class KrakenTrainer(pl.Trainer):
                 kwargs['logger'] = pl.loggers.TensorBoardLogger(log_dir)
         else:
             kwargs['logger'] = False
-        if 'mixed' in kwargs['precision']:
-            precision = kwargs['precision'].split('-')[0]
-            kwargs['precision'] = precision
-            if torch.cuda.is_available():
-                kwargs['plugins'] = [pl.plugins.precision.MixedPrecisionPlugin(precision, 'cuda')]
         kwargs['enable_checkpointing'] = False
         kwargs['enable_progress_bar'] = enable_progress_bar
         kwargs['min_epochs'] = min_epochs

--- a/kraken/lib/train.py
+++ b/kraken/lib/train.py
@@ -77,6 +77,10 @@ class KrakenTrainer(pl.Trainer):
                 kwargs['logger'] = pl.loggers.TensorBoardLogger(log_dir)
         else:
             kwargs['logger'] = False
+        if 'mixed' in kwargs['precision']:
+            precision = kwargs['precision'].split('-')[0]
+            kwargs['precision'] = precision
+            kwargs['plugins'] = [pl.plugins.precision.MixedPrecisionPlugin(precision, 'cuda')]
         kwargs['enable_checkpointing'] = False
         kwargs['enable_progress_bar'] = enable_progress_bar
         kwargs['min_epochs'] = min_epochs


### PR DESCRIPTION
Add a `--precision` option to `ketos train` and `ketos segtrain` to choose the numerical precision to use during training as discussed in #451. It can be set to: '32', 'bf16', '16', '16-mixed', 'bf16-mixed'. The default is `16-mixed`.