### PR TITLE
Keep PL Logger config in `KrakenTrainer`

### DIFF
--- a/kraken/ketos/recognition.py
+++ b/kraken/ketos/recognition.py
@@ -245,7 +245,6 @@ def train(ctx, batch_size, pad, output, spec, append, load, freq, quit, epochs,
                          'normalization': normalization,
                          'normalize_whitespace': normalize_whitespace,
                          'augment': augment,
-                         'pl_logger': pl_logger,
                          })
 
     # disable automatic partition when given evaluation set explicitly

--- a/kraken/ketos/segmentation.py
+++ b/kraken/ketos/segmentation.py
@@ -270,7 +270,6 @@ def segtrain(ctx, output, spec, line_width, pad, load, freq, quit, epochs,
                          'step_size': step_size,
                          'rop_patience': sched_patience,
                          'cos_t_max': cos_max,
-                         'pl_logger': pl_logger,
                          })
 
     # disable automatic partition when given evaluation set explicitly

--- a/kraken/lib/default_specs.py
+++ b/kraken/lib/default_specs.py
@@ -49,8 +49,6 @@ RECOGNITION_PRETRAIN_HYPER_PARAMS = {'pad': 16,
                                      'num_negatives': 100,
                                      'logit_temp': 0.1,
                                      'warmup': 32000,
-                                     # loggers
-                                     'pl_logger': None,
                                      }
 
 RECOGNITION_HYPER_PARAMS = {'pad': 16,
@@ -81,8 +79,6 @@ RECOGNITION_HYPER_PARAMS = {'pad': 16,
                             'cos_t_max': 50,
                             'warmup': 0,
                             'freeze_backbone': 0,
-                            # loggers
-                            'pl_logger': None,
                             }
 
 SEGMENTATION_HYPER_PARAMS = {'line_width': 8,
@@ -110,6 +106,4 @@ SEGMENTATION_HYPER_PARAMS = {'line_width': 8,
                              # cosine
                              'cos_t_max': 50,
                              'warmup': 0,
-                             # loggers
-                             'pl_logger': None,
                              }


### PR DESCRIPTION
## What this does

This closes #477 by keeping all data concerning PyTorch Lightning's `TensorBoardLogger` in the CLI commands and `KrakenTrainer`, not the Lightning Modules' hyperparameters.
As discussed in #477 this is useful when you create a `KrakenTrainer` yourself and want to give more options to the TensorBoardLogger. If you use the `ketos` command with `--logger tensorboard`, nothing should change.

## Detailed changes

- Remove `pl_logger` from (default) hyperparameters for `RecognitionModel` and `SegmentationModel`;
- Check for existing PL Logger before creating a default `TensorBoardLogger` during initialisation of `KrakenTrainer`;
- Add `LearningRateMonitor` callback during Trainer init instead of Module setup.

## To discuss

A `ValueError` is raised if the value for `pl_logger` is not a Logger or the `tensorboard` string and the `logger` keyword argument is not a Logger. I think an error would be raised in this case later on anyway, when the learning-rate monitor is added, but it felt appropriate to raise here, where the problem is.

## Additional notes

Note that an error will be raised if the TensorBoardLogger is initialised with `log_graph=True`. This happens because the `forward` method in the `RecognitionModel` returns or may return a tuple with `None` as the second element, which interferes with logging the graph of the neural network.