### PR TITLE
Enhancement/add resize and fix a regression for union

### DIFF
--- a/docs/ketos.rst
+++ b/docs/ketos.rst
@@ -25,7 +25,7 @@ Recognition model training
 * Increase the amount of --workers to speedup data loading. This is essential when you use the --augment option.
 * When using an Nvidia GPU, set the --precision option to 16 to use automatic mixed precision (AMP). This can provide significant speedup without any loss in accuracy.
 * Use option -B to scale batch size until GPU utilization reaches 100%. When using a larger batch size, it is recommended to use option -r to scale the learning rate by the square root of the batch size (1e-3 * sqrt(batch_size)).
-* When fine-tuning, it is recommended to use both mode not add as the network will rapidly unlearn missing labels in the new dataset.
+* When fine-tuning, it is recommended to use `new` mode not `union` as the network will rapidly unlearn missing labels in the new dataset.
 * If the new dataset is fairly dissimilar or your base model has been pretrained with ketos pretrain, use --warmup in conjunction with --freeze-backbone for one 1 or 2 epochs.
 * Upload your models to the model repository.
 
@@ -159,7 +159,7 @@ option                                                  action
 -u, \--normalization                                    Ground truth Unicode normalization. One of NFC, NFKC, NFD, NFKD.
 -c, \--codec                                            Load a codec JSON definition (invalid if loading existing model)
 \--resize                                               Codec/output layer resizing option. If set
-                                                        to `add` code points will be added, `both`
+                                                        to `union` code points will be added, `new`
                                                         will set the layer to match exactly the
                                                         training data, `fail` will abort if training
                                                         data and model codec do not match. Only valid when refining an existing model.
@@ -263,15 +263,15 @@ an exact match. Otherwise an error will be raised:
         Network codec not compatible with training set
         [0.8620] Training data and model codec alphabets mismatch: {'ٓ', '؟', '!', 'ص', '،', 'ذ', 'ة', 'ي', 'و', 'ب', 'ز', 'ح', 'غ', '~', 'ف', ')', 'د', 'خ', 'م', '»', 'ع', 'ى', 'ق', 'ش', 'ا', 'ه', 'ك', 'ج', 'ث', '(', 'ت', 'ظ', 'ض', 'ل', 'ط', '؛', 'ر', 'س', 'ن', 'ء', 'ٔ', '«', 'ـ', 'ٕ'} 
         
-There are two modes dealing with mismatching alphabets, ``add`` and ``both``.
-``add`` resizes the output layer and codec of the loaded model to include all
-characters in the new training set without removing any characters. ``both``
+There are two modes dealing with mismatching alphabets, ``union`` and ``new``.
+``union`` resizes the output layer and codec of the loaded model to include all
+characters in the new training set without removing any characters. ``new``
 will make the resulting model an exact match with the new training set by both
 removing unused characters from the model and adding new ones.
 
 .. code-block:: console
 
-        $ ketos -v train --resize add -i model_5.mlmodel syr/*.png
+        $ ketos -v train --resize union -i model_5.mlmodel syr/*.png
         ...
         [0.7943] Training set 788 lines, validation set 88 lines, alphabet 50 symbols
         ...
@@ -284,7 +284,7 @@ recognize 52 different characters after sufficient additional training.
 
 .. code-block:: console
 
-        $ ketos -v train --resize both -i model_5.mlmodel syr/*.png
+        $ ketos -v train --resize new -i model_5.mlmodel syr/*.png
         ...
         [0.7593] Training set 788 lines, validation set 88 lines, alphabet 49 symbols
         ...
@@ -292,7 +292,7 @@ recognize 52 different characters after sufficient additional training.
         [0.8344] Deleting 2 output classes from network (46 retained)
         ...
 
-In ``both`` mode 2 of the original characters were removed and 3 new ones were added.
+In ``new`` mode 2 of the original characters were removed and 3 new ones were added.
 
 Slicing
 ~~~~~~~
@@ -547,7 +547,7 @@ Fine tuning/transfer learning with last layer adaptation and slicing:
 
 .. code-block:: console
 
-        $ ketos segtrain --resize both -i segmodel_best.mlmodel training_data/*.xml
+        $ ketos segtrain --resize new -i segmodel_best.mlmodel training_data/*.xml
         $ ketos segtrain -i segmodel_best.mlmodel --append 7 -s '[Cr3,3,64 Do0.1]' training_data/*.xml
 
 In addition there are a couple of specific options that allow filtering of

--- a/kraken/ketos/recognition.py
+++ b/kraken/ketos/recognition.py
@@ -134,9 +134,14 @@ logger = logging.getLogger('kraken')
               default=RECOGNITION_HYPER_PARAMS['normalize_whitespace'], help='Normalizes unicode whitespace')
 @click.option('-c', '--codec', show_default=True, default=None, type=click.File(mode='r', lazy=True),
               help='Load a codec JSON definition (invalid if loading existing model)')
-@click.option('--resize', show_default=True, default='fail', type=click.Choice(['add', 'both', 'fail']),
-              help='Codec/output layer resizing option. If set to `add` code '
-                   'points will be added, `both` will set the layer to match exactly '
+@click.option('--resize', show_default=True, default='fail',
+              type=click.Choice([
+                  'add', 'union',  # Deprecation: `add` is deprecated, `union` is the new value
+                  'both', 'new',  # Deprecation: `both` is deprecated, `new` is the new value
+                  'fail'
+              ]),
+              help='Codec/output layer resizing option. If set to `union` code '
+                   'points will be added, `new` will set the layer to match exactly '
                    'the training data, `fail` will abort if training data and model '
                    'codec do not match.')
 @click.option('--reorder/--no-reorder', show_default=True, default=True, help='Reordering of code points to display order')
@@ -309,7 +314,7 @@ def train(ctx, batch_size, pad, output, spec, append, load, freq, quit, epochs,
         trainer.fit(model)
     except KrakenInputException as e:
         if e.args[0].startswith('Training data and model codec alphabets mismatch') and resize == 'fail':
-            raise click.BadOptionUsage('resize', 'Mismatched training data for loaded model. Set option `--resize` to `add` or `both`')
+            raise click.BadOptionUsage('resize', 'Mismatched training data for loaded model. Set option `--resize` to `new` or `add`')
         else:
             raise e
 

--- a/kraken/ketos/segmentation.py
+++ b/kraken/ketos/segmentation.py
@@ -193,7 +193,12 @@ def _validate_merging(ctx, param, value):
               show_default=True,
               default=SEGMENTATION_HYPER_PARAMS['augment'],
               help='Enable image augmentation')
-@click.option('--resize', show_default=True, default='fail', type=click.Choice(['add', 'both', 'fail']),
+@click.option('--resize', show_default=True, default='fail',
+              type=click.Choice([
+                  'add', 'union',  # Deprecation: `add` is deprecated, `union` is the new value
+                  'both', 'new',  # Deprecation: `both` is deprecated, `new` is the new value
+                  'fail'
+              ]),
               help='Output layer resizing option. If set to `add` new classes will be '
                    'added, `both` will set the layer to match exactly '
                    'the training data classes, `fail` will abort if training data and model '

--- a/kraken/lib/train.py
+++ b/kraken/lib/train.py
@@ -218,7 +218,7 @@ class RecognitionModel(pl.LightningModule):
             **kwargs: Setup parameters, i.e. CLI parameters of the train() command.
         """
         super().__init__()
-        hyper_params_ = default_specs.RECOGNITION_HYPER_PARAMS
+        hyper_params_ = default_specs.RECOGNITION_HYPER_PARAMS.copy()
         if model:
             logger.info(f'Loading existing model from {model} ')
             self.nn = vgsl.TorchVGSLModel.load_model(model)
@@ -696,7 +696,7 @@ class SegmentationModel(pl.LightningModule):
         self.bounding_regions = bounding_regions
         self.topline = topline
 
-        hyper_params_ = default_specs.SEGMENTATION_HYPER_PARAMS
+        hyper_params_ = default_specs.SEGMENTATION_HYPER_PARAMS.copy()
 
         if model:
             logger.info(f'Loading existing model from {model}')

--- a/kraken/lib/train.py
+++ b/kraken/lib/train.py
@@ -201,7 +201,7 @@ class RecognitionModel(pl.LightningModule):
                  force_binarization: bool = False,
                  format_type: Literal['path', 'alto', 'page', 'xml', 'binary'] = 'path',
                  codec: Optional[Dict] = None,
-                 resize: Literal['fail', 'add', 'both'] = 'fail'):
+                 resize: Literal['fail', 'both', 'new', 'add', 'union'] = 'fail'):
         """
         A LightningModule encapsulating the training setup for a text
         recognition model.
@@ -242,6 +242,13 @@ class RecognitionModel(pl.LightningModule):
         self.append = append
         self.model = model
         self.num_workers = num_workers
+        if resize == "add":
+            resize = "union"
+            warnings.warn("'add' value for resize has been deprecated. Use 'union' instead.", DeprecationWarning)
+        elif resize == "both":
+            resize = "new"
+            warnings.warn("'both' value for resize has been deprecated. Use 'new' instead.", DeprecationWarning)
+
         self.resize = resize
         self.format_type = format_type
         self.output = output
@@ -487,8 +494,8 @@ class RecognitionModel(pl.LightningModule):
             elif self.model:
                 self.spec = self.nn.spec
 
-                # prefer explicitly given codec over network codec if mode is 'both'
-                codec = self.codec if (self.codec and self.resize == 'both') else self.nn.codec
+                # prefer explicitly given codec over network codec if mode is 'new'
+                codec = self.codec if (self.codec and self.resize == 'new') else self.nn.codec
 
                 codec.strict = True
 
@@ -500,7 +507,7 @@ class RecognitionModel(pl.LightningModule):
                     )
                     if self.resize == 'fail':
                         raise KrakenInputException(f'Training data and model codec alphabets mismatch: {alpha_diff}')
-                    elif self.resize == 'add':
+                    elif self.resize == 'union':
                         logger.info(f'Resizing codec to include '
                                     f'{len(alpha_diff)} new code points')
                         # Construct two codecs:
@@ -512,7 +519,7 @@ class RecognitionModel(pl.LightningModule):
                         logger.info(f'Resizing last layer in network to {codec.max_label+1} outputs')
                         self.nn.resize_output(codec.max_label + 1)
                         self.train_set.dataset.encode(train_codec)
-                    elif self.resize == 'both':
+                    elif self.resize == 'new':
                         logger.info(f'Resizing network or given codec to '
                                     f'{len(self.train_set.dataset.alphabet)} '
                                     f'code sequences')
@@ -649,7 +656,7 @@ class SegmentationModel(pl.LightningModule):
                  merge_regions: Optional[Dict[str, str]] = None,
                  merge_baselines: Optional[Dict[str, str]] = None,
                  bounding_regions: Optional[Sequence[str]] = None,
-                 resize: Literal['fail', 'both', 'add'] = 'fail',
+                 resize: Literal['fail', 'both', 'new', 'add', 'union'] = 'fail',
                  topline: Union[bool, None] = False):
         """
         A LightningModule encapsulating the training setup for a page
@@ -674,7 +681,15 @@ class SegmentationModel(pl.LightningModule):
 
         self.model = model
         self.num_workers = num_workers
+
+        if resize == "add":
+            resize = "union"
+            warnings.warn("'add' value for resize has been deprecated. Use 'union' instead.", DeprecationWarning)
+        elif resize == "both":
+            resize = "new"
+            warnings.warn("'both' value for resize has been deprecated. Use 'new' instead.", DeprecationWarning)
         self.resize = resize
+
         self.format_type = format_type
         self.output = output
         self.bounding_regions = bounding_regions
@@ -868,7 +883,7 @@ class SegmentationModel(pl.LightningModule):
 
                     if self.resize == 'fail':
                         raise ValueError(f'Training data and model class mapping differ (bl: {bl_diff}, regions: {regions_diff}')
-                    elif self.resize == 'add':
+                    elif self.resize == 'union':
                         new_bls = self.train_set.dataset.class_mapping['baselines'].keys() - self.nn.user_metadata['class_mapping']['baselines'].keys()
                         new_regions = self.train_set.dataset.class_mapping['regions'].keys() - self.nn.user_metadata['class_mapping']['regions'].keys()
                         cls_idx = max(max(self.nn.user_metadata['class_mapping']['baselines'].values()) if self.nn.user_metadata['class_mapping']['baselines'] else -1,
@@ -881,7 +896,7 @@ class SegmentationModel(pl.LightningModule):
                         for c in new_regions:
                             cls_idx += 1
                             self.nn.user_metadata['class_mapping']['regions'][c] = cls_idx
-                    elif self.resize == 'both':
+                    elif self.resize == 'new':
                         logger.info('Fitting network exactly to training set.')
                         new_bls = self.train_set.dataset.class_mapping['baselines'].keys() - self.nn.user_metadata['class_mapping']['baselines'].keys()
                         new_regions = self.train_set.dataset.class_mapping['regions'].keys() - self.nn.user_metadata['class_mapping']['regions'].keys()

--- a/kraken/lib/train.py
+++ b/kraken/lib/train.py
@@ -516,8 +516,8 @@ class RecognitionModel(pl.LightningModule):
                         # This keep the codec in the model from being 'polluted' by non-trained characters.
                         train_codec = codec.add_labels(alpha_diff)
                         self.nn.add_codec(train_codec)
-                        logger.info(f'Resizing last layer in network to {codec.max_label+1} outputs')
-                        self.nn.resize_output(codec.max_label + 1)
+                        logger.info(f'Resizing last layer in network to {train_codec.max_label+1} outputs')
+                        self.nn.resize_output(train_codec.max_label + 1)
                         self.train_set.dataset.encode(train_codec)
                     elif self.resize == 'new':
                         logger.info(f'Resizing network or given codec to '
@@ -535,6 +535,7 @@ class RecognitionModel(pl.LightningModule):
                     else:
                         raise ValueError(f'invalid resize parameter value {self.resize}')
                 self.nn.codec.strict = False
+                self.spec = self.nn.spec
             else:
                 self.train_set.dataset.encode(self.codec)
                 logger.info(f'Creating new model {self.spec} with {self.train_set.dataset.codec.max_label+1} outputs')

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -50,9 +50,9 @@ class TestKrakenTrainer(unittest.TestCase):
         with raises(KrakenInputException):
             module.setup()
 
-    def test_krakentrainer_rec_box_load_add(self):
+    def test_krakentrainer_rec_box_load_union(self):
         """
-        Tests that adaptation works in add mode.
+        Tests that adaptation works in `union` mode.
         """
         training_data = self.box_lines
         evaluation_data = self.box_lines
@@ -60,16 +60,16 @@ class TestKrakenTrainer(unittest.TestCase):
                                   model=self.model,
                                   training_data=training_data,
                                   evaluation_data=evaluation_data,
-                                  resize='add')
+                                  resize='union')
         module.setup()
         self.assertEqual(module.nn.seg_type, 'bbox')
         self.assertIsInstance(module.train_set.dataset, kraken.lib.dataset.GroundTruthDataset)
         trainer = KrakenTrainer(max_steps=1)
         self.assertEqual(module.nn.named_spec[-1].split("c")[-1], '19')
 
-    def test_krakentrainer_rec_box_load_both(self):
+    def test_krakentrainer_rec_box_load_new(self):
         """
-        Tests that adaptation works in both mode.
+        Tests that adaptation works in `new` mode.
         """
         training_data = self.box_lines
         evaluation_data = self.box_lines
@@ -77,7 +77,7 @@ class TestKrakenTrainer(unittest.TestCase):
                                   model=self.model,
                                   training_data=training_data,
                                   evaluation_data=evaluation_data,
-                                  resize='both')
+                                  resize='new')
         module.setup()
         self.assertEqual(module.nn.seg_type, 'bbox')
         self.assertIsInstance(module.train_set.dataset, kraken.lib.dataset.GroundTruthDataset)
@@ -113,28 +113,28 @@ class TestKrakenTrainer(unittest.TestCase):
         with raises(KrakenInputException):
             module.setup()
 
-    def test_krakentrainer_rec_bl_load_add(self):
+    def test_krakentrainer_rec_bl_load_union(self):
         training_data = [self.xml]
         evaluation_data = [self.xml]
         module = RecognitionModel(format_type='xml',
                                   model=self.model,
                                   training_data=training_data,
                                   evaluation_data=evaluation_data,
-                                  resize='add')
+                                  resize='union')
         module.setup()
         self.assertEqual(module.nn.seg_type, 'baselines')
         self.assertIsInstance(module.train_set.dataset, kraken.lib.dataset.PolygonGTDataset)
         trainer = KrakenTrainer(max_steps=1)
         self.assertEqual(module.nn.named_spec[-1].split("c")[-1], '60')
 
-    def test_krakentrainer_rec_bl_load_both(self):
+    def test_krakentrainer_rec_bl_load_new(self):
         training_data = [self.xml]
         evaluation_data = [self.xml]
         module = RecognitionModel(format_type='xml',
                                   model=self.model,
                                   training_data=training_data,
                                   evaluation_data=evaluation_data,
-                                  resize='both')
+                                  resize='new')
         module.setup()
         self.assertEqual(module.nn.seg_type, 'baselines')
         self.assertIsInstance(module.train_set.dataset, kraken.lib.dataset.PolygonGTDataset)

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -53,6 +53,8 @@ class TestKrakenTrainer(unittest.TestCase):
     def test_krakentrainer_rec_box_load_union(self):
         """
         Tests that adaptation works in `union` mode.
+
+        The dataset brings 15 new characters. Input model had 3. There is one spec. char to account for.
         """
         training_data = self.box_lines
         evaluation_data = self.box_lines
@@ -61,7 +63,7 @@ class TestKrakenTrainer(unittest.TestCase):
                                   training_data=training_data,
                                   evaluation_data=evaluation_data,
                                   resize='union')
-        module.setup()
+        module.setup("fit")
         self.assertEqual(module.nn.seg_type, 'bbox')
         self.assertIsInstance(module.train_set.dataset, kraken.lib.dataset.GroundTruthDataset)
         trainer = KrakenTrainer(max_steps=1)
@@ -78,7 +80,7 @@ class TestKrakenTrainer(unittest.TestCase):
                                   training_data=training_data,
                                   evaluation_data=evaluation_data,
                                   resize='new')
-        module.setup()
+        module.setup("fit")
         self.assertEqual(module.nn.seg_type, 'bbox')
         self.assertIsInstance(module.train_set.dataset, kraken.lib.dataset.GroundTruthDataset)
         trainer = KrakenTrainer(max_steps=1)


### PR DESCRIPTION
This fixes #478 and #487.

I discovered a potential regression where the train_codec was not used to resize the output layer. This was causing #487 

I added some deprecation regarding #478. 

Test and docs are updated