### PR TITLE
Transposed Convolution

### DIFF
--- a/kraken/lib/layers.py
+++ b/kraken/lib/layers.py
@@ -21,12 +21,15 @@ class MultiParamSequential(Sequential):
     Sequential variant accepting multiple arguments.
     """
 
-    def forward(self, *inputs):
-        for module in self._modules.values():
+    def forward(self, *inputs, output_shape: Optional[Tuple[int, int]] = None):
+        modules = self._modules.values()
+        i = 0
+        for module in modules:
             if type(inputs) == tuple:
-                inputs = module(*inputs)
+                inputs = module(*inputs, output_shape=output_shape if i == len(modules) - 1 else None)
             else:
-                inputs = module(inputs)
+                inputs = module(inputs, output_shape=output_shape if i == len(modules) - 1 else None)
+            i += 1
         return inputs
 
 
@@ -34,15 +37,17 @@ class MultiParamParallel(Module):
     """
     Parallel module.
     """
-    def forward(self, *inputs):
+    def forward(self, *inputs, output_shape: Optional[Tuple[int, int]] = None):
         outputs = []
         seq_lens = None
         for module in self._modules.values():
             if type(inputs) == tuple:
-                output, seq_lens = module(*inputs)
+                output, seq_lens = module(*inputs, output_shape=output_shape)
                 outputs.append(output)
             else:
-                outputs.append(module(inputs))
+                outputs.append(module(inputs, output_shape=output_shape))
+            if output_shape is None:
+                output_shape = outputs[-1].shape[2:]
         return torch.cat(outputs, dim=1), seq_lens
 
 
@@ -145,7 +150,7 @@ class PeepholeBidiLSTM(Module):
                 setattr(self, name, param)
             self._all_weights.append(param_names)
 
-    def forward(self, input: torch.Tensor) -> torch.Tensor:
+    def forward(self, input: torch.Tensor, output_shape: Optional[List[int]] = None) -> torch.Tensor:
         layer = (Recurrent(PeepholeLSTMCell), Recurrent(PeepholeLSTMCell, reverse=True))
         func = StackedRNN(layer, 1, 2)
         input = input.transpose(0, 1)
@@ -177,7 +182,7 @@ class Addition(Module):
         self.chunk_size = chunk_size
         super().__init__()
 
-    def forward(self, inputs: torch.Tensor, seq_len: Optional[torch.Tensor] = None) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    def forward(self, inputs: torch.Tensor, seq_len: Optional[torch.Tensor] = None, output_shape: Optional[List[int]] = None) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
         out = inputs.unfold(self.dim, self.chunk_size, self.chunk_size)
         out = out.sum(self.dim, keepdim=True)
         out = out.transpose(-1, self.dim).squeeze(-1)
@@ -227,7 +232,7 @@ class Identity(Module):
         """
         super().__init__()
 
-    def forward(self, inputs: torch.Tensor, seq_len: Optional[torch.Tensor] = None) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    def forward(self, inputs: torch.Tensor, seq_len: Optional[torch.Tensor] = None, output_shape: Optional[Tuple[int, int]] = None) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
         return inputs, seq_len
 
     def get_shape(self, input: Tuple[int, int, int, int]) -> Tuple[int, int, int, int]:
@@ -279,7 +284,7 @@ class Reshape(Module):
         self.high = high
         self.low = low
 
-    def forward(self, input: torch.Tensor, seq_len: Optional[torch.Tensor] = None) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    def forward(self, input: torch.Tensor, seq_len: Optional[torch.Tensor] = None, output_shape: Optional[Tuple[int, int]] = None) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
         initial_len = input.shape[3]
         # split dimension src_dim into part_a x part_b
         input = input.reshape(input.shape[:self.src_dim] + (self.part_a, self.part_b) + input.shape[self.src_dim + 1:])
@@ -344,7 +349,7 @@ class MaxPool(Module):
         self.stride = stride
         self.layer = torch.nn.MaxPool2d(kernel_size, stride)
 
-    def forward(self, inputs: torch.Tensor, seq_len: Optional[torch.Tensor] = None) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    def forward(self, inputs: torch.Tensor, seq_len: Optional[torch.Tensor] = None, output_shape: Optional[Tuple[int, int]] = None) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
         o = self.layer(inputs)
         if seq_len is not None:
             seq_len = torch.floor((seq_len-(self.kernel_size[1]-1)-1).float()/self.stride[1]+1).int()
@@ -393,7 +398,7 @@ class Dropout(Module):
         elif dim == 2:
             self.layer = torch.nn.Dropout2d(p)
 
-    def forward(self, inputs: torch.Tensor, seq_len: Optional[torch.Tensor] = None) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    def forward(self, inputs: torch.Tensor, seq_len: Optional[torch.Tensor] = None, output_shape: Optional[Tuple[int, int]] = None) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
         return self.layer(inputs), seq_len
 
     def get_shape(self, input: Tuple[int, int, int, int]) -> Tuple[int, int, int, int]:
@@ -469,7 +474,7 @@ class TransposedSummarizingRNN(Module):
                                        batch_first=True,
                                        bias=False if legacy else True)
 
-    def forward(self, inputs: torch.Tensor, seq_len: Optional[torch.Tensor] = None) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    def forward(self, inputs: torch.Tensor, seq_len: Optional[torch.Tensor] = None, output_shape: Optional[Tuple[int, int]] = None) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
         # NCHW -> HNWC
         inputs = inputs.permute(2, 0, 3, 1)
         if self.transpose:
@@ -661,7 +666,7 @@ class LinSoftmax(Module):
 
         self.lin = torch.nn.Linear(self.input_size, output_size)
 
-    def forward(self, inputs: torch.Tensor, seq_len: Optional[torch.Tensor] = None) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    def forward(self, inputs: torch.Tensor, seq_len: Optional[torch.Tensor] = None, output_shape: Optional[Tuple[int, int]] = None) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
         # move features (C) to last dimension for linear activation
         # NCHW -> NWHC
         inputs = inputs.transpose(1, 3)
@@ -735,20 +740,21 @@ class LinSoftmax(Module):
         self.lin.weight = torch.nn.Parameter(weight)
         self.lin.bias = torch.nn.Parameter(bias)
 
-
 class ActConv2D(Module):
     """
     A wrapper for convolution + activation with automatic padding ensuring no
     dropped columns.
     """
 
-    def __init__(self, in_channels: int, out_channels: int, kernel_size: Tuple[int, int], stride: Tuple[int, int], nl: str = 'l') -> None:
+    def __init__(self, in_channels: int, out_channels: int, kernel_size: Tuple[int, int], stride: Tuple[int, int], nl: str = 'l', transposed: bool = False) -> None:
         super().__init__()
         self.in_channels = in_channels
         self.kernel_size = kernel_size
         self.out_channels = out_channels
         self.stride = stride
         self.padding = tuple((k - 1) // 2 for k in kernel_size)
+        self.transposed = transposed
+        
         if nl == 's':
             self.nl = torch.sigmoid
             self.nl_name = 'SIGMOID'
@@ -767,22 +773,45 @@ class ActConv2D(Module):
         else:
             self.nl_name = 'LINEAR'
             self.nl = lambda x: x
-        self.co = torch.nn.Conv2d(in_channels, out_channels, kernel_size,
+        
+        if self.transposed:
+            self.co = torch.nn.ConvTranspose2d(in_channels, out_channels, kernel_size,
                                   stride=stride, padding=self.padding)
+        else:
+            self.co = torch.nn.Conv2d(in_channels, out_channels, kernel_size,
+                                      stride=stride, padding=self.padding)
 
-    def forward(self, inputs: torch.Tensor, seq_len: Optional[torch.Tensor] = None) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
-        o = self.co(inputs)
+    def forward(self, inputs: torch.Tensor, seq_len: Optional[torch.Tensor] = None, output_shape: Optional[Tuple[int, int]] = None) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        if self.transposed:
+            o = self.co(inputs, output_size=output_shape)
+        else:
+            o = self.co(inputs)
         # return logits for sigmoid activation during training
         if not (self.nl_name == 'SIGMOID' and self.training):
             o = self.nl(o)
 
         if seq_len is not None:
-            seq_len = torch.clamp(torch.floor(
-                (seq_len+2*self.padding[1]-(self.kernel_size[1]-1)-1).float()/self.stride[1]+1), min=1).int()
+            if self.transposed:
+                seq_len = torch.floor(
+                    ((seq_len - 1) * self.stride[1] - 2 * self.padding[1] + self.kernel_size[1]))
+            else:
+                seq_len = torch.clamp(torch.floor(
+                    (seq_len+2*self.padding[1]-(self.kernel_size[1]-1)-1).float()/self.stride[1]+1), min=1).int()
         return o, seq_len
 
-    def get_shape(self, input: Tuple[int, int, int, int]) -> Tuple[int, int, int, int]:
-        self.output_shape = (input[0],
+    def get_shape(self, input: Tuple[int, int, int, int], target_shape: Optional[Tuple[int, int, int, int]] = None) -> Tuple[int, int, int, int]:
+        if self.transposed:
+            """ For transposed convolution, there is some flexibilty. """
+            min_y = int((input[2] - 1) * self.stride[0] - 2 * self.padding[0] + self.kernel_size[0] if input[2] != 0 else 0)
+            target_y = min_y if not target_shape or target_shape[2] == 0 else target_shape[2]
+            min_x = int((input[3] - 1) * self.stride[1] - 2 * self.padding[1] + self.kernel_size[1] if input[3] != 0 else 0)
+            target_x = min_x if not target_shape or target_shape[3] == 0 else target_shape[3]
+            self.output_shape = (input[0],
+                                 self.out_channels,
+                                 min(min_y + self.stride[0] - 1, max(target_y, min_y)),
+                                 min(min_x + self.stride[1] - 1, max(target_x, min_x)))
+        else:
+            self.output_shape = (input[0],
                              self.out_channels,
                              int(max(np.floor((input[2]+2*self.padding[0]-(self.kernel_size[0]-1)-1) /
                                  self.stride[0]+1), 1) if input[2] != 0 else 0),
@@ -817,6 +846,7 @@ class ActConv2D(Module):
                                 W=self.co.weight.permute(2, 3, 1, 0).data.numpy(),
                                 b=self.co.bias.data.numpy(),
                                 has_bias=True,
+                                is_deconv=self.transposed,
                                 input_name=input,
                                 output_name=conv_name)
         if self.nl_name != 'SOFTMAX':
@@ -848,8 +878,12 @@ class ActConv2D(Module):
         weight = torch.cat([weight, rweight], dim=0)
         bias = self.co.bias.index_select(0, idx)
         bias = torch.cat([bias, torch.zeros(output_size - bias.size(0))])
-        self.co = torch.nn.Conv2d(self.in_channels, self.out_channels, self.kernel_size,
-                                  stride=self.stride, padding=self.padding)
+        if self.transposed:
+            self.co = torch.nn.ConvTranspose2d(self.in_channels, self.out_channels, self.kernel_size,
+                                      stride=self.stride, padding=self.padding)
+        else:
+            self.co = torch.nn.Conv2d(self.in_channels, self.out_channels, self.kernel_size,
+                                      stride=self.stride, padding=self.padding)
         self.co.weight = torch.nn.Parameter(weight)
         self.co.bias = torch.nn.Parameter(bias)
 
@@ -866,7 +900,7 @@ class GroupNorm(Module):
 
         self.layer = torch.nn.GroupNorm(num_groups, in_channels)
 
-    def forward(self, inputs: torch.Tensor, seq_len: Optional[torch.Tensor]) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    def forward(self, inputs: torch.Tensor, seq_len: Optional[torch.Tensor], output_shape: Optional[Tuple[int, int]] = None) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
         t = inputs.dtype
         # XXX: verify that pytorch AMP casts the inputs to float32 correctly at
         # some point.


### PR DESCRIPTION
Add a transposed convolution type to VGSL.
In order to match the output size in parallel layers, I added a parameter to the forward pass that describes the expected output size of the layer. (This is maybe a bit awkward and also does not work correctly if the transposed convolution is not the very last layer before the parallel block ends)