### PR TITLE
Allow multi-line description for `ketos publish`

### DIFF
--- a/kraken/metadata.schema.json
+++ b/kraken/metadata.schema.json
@@ -52,8 +52,7 @@
      "description": {
        "$id": "#/properties/description",
        "type": "string",
-       "title": "A long-form description of the model.",
-       "pattern": "^(.*)$"
+       "title": "A long-form description of the model."
      },
      "accuracy": {
        "$id": "#/properties/accuracy",


### PR DESCRIPTION
`ketos publish` suggests to enter a long description, opens an editor which invites to enter more than a single line, but aborts then because the old pattern only allows a single line.