### PR TITLE
Update requirements for torchmetrics and related import statement

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -31,7 +31,7 @@ requirements:
      - coremltools
      - pyarrow
      - pytorch-lightning~=2.0
-     - torchmetrics>=0.10.0
+     - torchmetrics>=1.1.0
      - albumentations
      - rich
 about:

--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,7 @@ dependencies:
   - imagemagick>=7.1.0
   - pyarrow
   - conda-forge::pytorch-lightning~=2.0.0
-  - conda-forge::torchmetrics>=0.10.0
+  - conda-forge::torchmetrics>=1.1.0
   - pip
   - albumentations
   - rich

--- a/environment_cuda.yml
+++ b/environment_cuda.yml
@@ -24,7 +24,7 @@ dependencies:
   - imagemagick>=7.1.0
   - pyarrow
   - conda-forge::pytorch-lightning~=2.0.0
-  - conda-forge::torchmetrics>=0.10.0
+  - conda-forge::torchmetrics>=1.1.0
   - pip
   - albumentations
   - rich

--- a/kraken/lib/train.py
+++ b/kraken/lib/train.py
@@ -26,8 +26,8 @@ import pytorch_lightning as pl
 from os import PathLike
 from functools import partial
 from torch.multiprocessing import Pool
-from torchmetrics import CharErrorRate, WordErrorRate
 from torchmetrics.classification import MultilabelAccuracy, MultilabelJaccardIndex
+from torchmetrics.text import CharErrorRate, WordErrorRate
 from torch.optim import lr_scheduler
 from typing import Callable, Dict, Optional, Sequence, Union, Any, Literal
 from pytorch_lightning.callbacks import Callback, EarlyStopping, BaseFinetuning, LearningRateMonitor

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,7 @@ install_requires =
     shapely~=1.8.5
     pyarrow
     pytorch-lightning~=2.0.0
-    torchmetrics>=0.10.0
+    torchmetrics>=1.1.0
     rich
 
 [options.extras_require]


### PR DESCRIPTION
A new installation of kraken gets torchmetrics 1.1.1 which wants a different import statement for CharErrorRate and WordErrorRate:

```
FutureWarning: Importing `CharErrorRate` from `torchmetrics` was deprecated and will be removed in 2.0. Import `CharErrorRate` from `torchmetrics.text` instead.
FutureWarning: Importing `WordErrorRate` from `torchmetrics` was deprecated and will be removed in 2.0. Import `WordErrorRate` from `torchmetrics.text` instead.
```

Update the import statement and require at least torchmetrics 1.1.0 which introduced the modified import.