### PR TITLE
Update deprecated import statement for scipy filters

### DIFF
--- a/kraken/pageseg.py
+++ b/kraken/pageseg.py
@@ -25,8 +25,7 @@ from typing import Callable, List, Optional, Tuple, Union
 
 import numpy as np
 import PIL
-from scipy.ndimage.filters import (gaussian_filter, maximum_filter,
-                                   uniform_filter)
+from scipy.ndimage import gaussian_filter, maximum_filter, uniform_filter
 
 from kraken.containers import BBoxLine, Segmentation
 from kraken.lib import morph, sl


### PR DESCRIPTION
This fixes some runtime warnings:

```
venv3.11/lib/python3.11/site-packages/kraken/pageseg.py:28
  venv3.11/lib/python3.11/site-packages/kraken/pageseg.py:28: DeprecationWarning: Please use `gaussian_filter` from the `scipy.ndimage` namespace, the `scipy.ndimage.filters` namespace is deprecated.
    from scipy.ndimage.filters import (gaussian_filter, maximum_filter,

venv3.11/lib/python3.11/site-packages/kraken/pageseg.py:28
  venv3.11/lib/python3.11/site-packages/kraken/pageseg.py:28: DeprecationWarning: Please use `maximum_filter` from the `scipy.ndimage` namespace, the `scipy.ndimage.filters` namespace is deprecated.
    from scipy.ndimage.filters import (gaussian_filter, maximum_filter,

venv3.11/lib/python3.11/site-packages/kraken/pageseg.py:28
  venv3.11/lib/python3.11/site-packages/kraken/pageseg.py:28: DeprecationWarning: Please use `uniform_filter` from the `scipy.ndimage` namespace, the `scipy.ndimage.filters` namespace is deprecated.
    from scipy.ndimage.filters import (gaussian_filter, maximum_filter,
```