### PR TITLE
Relax requirements for scipy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     numpy~=1.23.0
     Pillow>=9.2.0
     regex
-    scipy~=1.10.0 # bump up to latest release with py3.8 EOL
+    scipy>1.10.0,<1.12.0 # remove 1.10 with py3.8 EOL
     protobuf>=3.0.0
     coremltools~=6.0
     jinja2~=3.0


### PR DESCRIPTION
Python 3.8 only supports scipy 1.10, but newer Python versions like 3.11 also work fine with scipy 1.11.