### PR TITLE
Enable test_pageseg in GitHub CI test action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Run tests, except training tests
         run: |
-          pytest -k 'not test_train and not test_pageseg'
+          pytest -k 'not test_train'
 
   build-n-publish-pypi:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI


### PR DESCRIPTION
That test passes and does not need much time, so there is no reason to exclude it from the test.