### PR TITLE
Print separate lines for pages in log output of extract_lines.py

### DIFF
--- a/kraken/contrib/extract_lines.py
+++ b/kraken/contrib/extract_lines.py
@@ -56,6 +56,7 @@ def cli(format_type, model, legacy_polygons, files):
                         im.save('{}.{}.jpg'.format(splitext(doc)[0], idx))
                         with open('{}.{}.gt.txt'.format(splitext(doc)[0], idx), 'w') as fp:
                             fp.write(sample['text'])
+            click.echo()
     else:
         net = vgsl.TorchVGSLModel.load_model(model)
         for doc in files:
@@ -65,6 +66,7 @@ def cli(format_type, model, legacy_polygons, files):
             for idx, (im, box) in enumerate(segmentation.extract_polygons(full_im, bounds, legacy=legacy_polygons)):
                 click.echo('.', nl=False)
                 im.save('{}.{}.jpg'.format(splitext(doc)[0], idx))
+            click.echo()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Instead of
```
Processing PPN1807526488/1807526488_0011.xml .....................................Processing PPN1807526488/1807526488_0005.xml ....Processing PPN1807526488/1807526488_0004.xml ..Processing PPN1807526488/1807526488_0010.xml .................................................Processing PPN1807526488/1807526488_0006.xml Processing PPN1807526488/1807526488_0012.xml ...................................Processing PPN1807526488/1807526488_0013.xml ........................Processing PPN1807526488/1807526488_0007.xml .....
```
it produces this log output:
```
Processing PPN1807526488/1807526488_0011.xml .....................................
Processing PPN1807526488/1807526488_0005.xml ....
Processing PPN1807526488/1807526488_0004.xml ..
[...]
```