### PR TITLE
Update alto to not produce Polygon tag on default blocks

### DIFF
--- a/kraken/templates/alto
+++ b/kraken/templates/alto
@@ -108,9 +108,9 @@
                 </TextBlock>
                 {% endif %}
                 <TextBlock ID="{{ entity.id }}" {% if entity.bbox %}HPOS="{{ entity.bbox[0] }}" VPOS="{{ entity.bbox[1] }}" WIDTH="{{ entity.bbox[2] - entity.bbox[0] }}" HEIGHT="{{ entity.bbox[3] - entity.bbox[1] }}"{% endif %} {% if entity.tags %}{% for type in page.region_types %}{% if type in entity.tags.values() %}TAGREFS="REGION_TYPE_{{ loop.index }}"{% endif %}{% endfor %}{% endif %}>
-                    <Shape>
+                    {% if entity.bbox %}<Shape>
                         <Polygon POINTS="{{ entity.boundary|sum(start=[])|join(' ') }}"/>
-                    </Shape>
+                    </Shape>{% endif %}
                     {%- for line in entity.lines -%}
                     {{ render_line(page, line) }}
                     {%- endfor -%}


### PR DESCRIPTION
This is a fix to the fix :)

The previous fix ends up producing document that you can't import in eScriptorium.