### PR TITLE
Adjust return value for image load error in extract line & line path

### DIFF
--- a/kraken/lib/arrow_dataset.py
+++ b/kraken/lib/arrow_dataset.py
@@ -50,8 +50,9 @@ def _extract_line(xml_record, skip_empty_lines: bool = True, legacy_polygons: bo
         im = Image.open(xml_record.imagename)
         if is_bitonal(im):
             im = im.convert('1')
-    except (OSError, FileNotFoundError, UnidentifiedImageError):
-        return lines, None, None
+    except (OSError, FileNotFoundError, UnidentifiedImageError) as err:
+        logger.warning(f'Error loading image {xml_record.imagename}: {err}')
+        return lines, None
     for idx, rec in enumerate(xml_record.lines):
         seg = Segmentation(text_direction='horizontal-lr',
                            imagename=xml_record.imagename,
@@ -79,10 +80,11 @@ def _extract_line(xml_record, skip_empty_lines: bool = True, legacy_polygons: bo
 def _extract_path_line(xml_record, skip_empty_lines: bool = True):
     try:
         im = Image.open(xml_record['image'])
-    except (FileNotFoundError, UnidentifiedImageError):
-        return [], None, None
+    except (FileNotFoundError, UnidentifiedImageError) as err:
+        logger.warning(f'Error loading image {xml_record.imagename}: {err}')
+        return [], None
     if not xml_record['lines'][0]['text'] and skip_empty_lines:
-        return [], None, None
+        return [], None
     if is_bitonal(im):
         im = im.convert('1')
     fp = io.BytesIO()


### PR DESCRIPTION
The `_extract_line` and `_extract_path_line` methods currently return a 3-tuple instead of a 2-tuple when there is an error loading the image file. This causes an error when the extract function is called by `map` or `imap_unordered` - it looks like a code error and it took me some digging to determine I was not setting the image path correctly for the `build_binary_dataset` method to be able to load the image files.

I've revised to return two values instead of three and added logging so that it will be easier to diagnose image problems; I wasn't sure if it should be a warning or an error, so kept it as a warning. 

I added a unit test based on the existing tests for the `build_binary_dataset` method.