### PR TITLE
Add missing dependencies for class DefaultAugmenter

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ exclude = tests/*
 [options]
 python_requires = >=3.9,<3.13
 install_requires =
+    albumentations
     jsonschema
     lxml
     requests
@@ -51,6 +52,7 @@ install_requires =
     protobuf>=3.0.0
     coremltools~=8.1
     jinja2~=3.0
+    opencv_python_headless
     python-bidi~=0.6.0
     torchvision>=0.5.0
     torch>=2.4.0,<=2.9


### PR DESCRIPTION
Without these dependencies, two tests fail when running pytest.