### PR TITLE
Rotate images according to EXIF metadata

### DIFF
--- a/kraken/align.py
+++ b/kraken/align.py
@@ -32,6 +32,7 @@ from bidi.algorithm import get_display
 from PIL import Image
 
 from kraken import rpred
+from kraken.lib.util import open_image
 from kraken.containers import BaselineOCRRecord, Segmentation
 
 if TYPE_CHECKING:
@@ -54,7 +55,7 @@ def forced_align(doc: Segmentation, model: 'TorchSeqRecognizer', base_dir: Optio
     """
     warnings.warn('`forced_align` is deprecated and will be removed with kraken 8. Use `ForcedAlignmentTaskModel` instead.',
                   DeprecationWarning)
-    im = Image.open(doc.imagename)
+    im = open_image(doc.imagename)
     predictor = rpred.rpred(model, im, doc)
 
     records = []

--- a/kraken/contrib/baselineset_overlay.py
+++ b/kraken/contrib/baselineset_overlay.py
@@ -16,6 +16,7 @@ def cli(files):
     from PIL import Image
 
     from kraken.lib import dataset
+    from kraken.lib.util import open_image
 
     batch, channels, height, width = 1, 3, 1200, 0
     transforms = dataset.ImageInputTransforms(batch, height, width, channels, 0, valid_norm=False)
@@ -27,7 +28,7 @@ def cli(files):
     for idx, batch in enumerate(ds):
         img = ds.imgs[idx]
         print(img)
-        im = Image.open(img)
+        im = open_image(img)
         res_tf = tf.Compose(transforms.transforms[:2])
         scal_im = res_tf(im)
         o = batch['target'].numpy()

--- a/kraken/contrib/extract_lines.py
+++ b/kraken/contrib/extract_lines.py
@@ -30,6 +30,7 @@ def cli(format_type, model, legacy_polygons, files):
 
     from kraken import blla
     from kraken.lib import segmentation, vgsl, xml
+    from kraken.lib.util import open_image
 
     if model is None:
         for doc in files:
@@ -38,7 +39,7 @@ def cli(format_type, model, legacy_polygons, files):
                 data = xml.XMLPage(doc, format_type)
                 if len(data.lines) > 0:
                     bounds = data.to_container()
-                    for idx, (im, box) in enumerate(segmentation.extract_polygons(Image.open(bounds.imagename), bounds, legacy=legacy_polygons)):
+                    for idx, (im, box) in enumerate(segmentation.extract_polygons(open_image(bounds.imagename), bounds, legacy=legacy_polygons)):
                         click.echo('.', nl=False)
                         im.save('{}.{}.jpg'.format(splitext(bounds.imagename)[0], idx))
                         with open('{}.{}.gt.txt'.format(splitext(bounds.imagename)[0], idx), 'w') as fp:
@@ -61,7 +62,7 @@ def cli(format_type, model, legacy_polygons, files):
         net = vgsl.TorchVGSLModel.load_model(model)
         for doc in files:
             click.echo(f'Processing {doc} ', nl=False)
-            full_im = Image.open(doc)
+            full_im = open_image(doc)
             bounds = blla.segment(full_im, model=net)
             for idx, (im, box) in enumerate(segmentation.extract_polygons(full_im, bounds, legacy=legacy_polygons)):
                 click.echo('.', nl=False)

--- a/kraken/contrib/forced_alignment_overlay.py
+++ b/kraken/contrib/forced_alignment_overlay.py
@@ -105,6 +105,7 @@ def cli(format_type, model, normalization, output, files):
 
     from kraken import align
     from kraken.lib import models
+    from kraken.lib.util import open_image
     from kraken.lib.xml import XMLPage
 
     if format_type == 'alto':
@@ -118,12 +119,12 @@ def cli(format_type, model, normalization, output, files):
     for doc in files:
         click.echo(f'Processing {doc} ', nl=False)
         data = XMLPage(doc)
-        im = Image.open(data.imagename).convert('RGBA')
+        im = open_image(data.imagename).convert('RGBA')
         result = align.forced_align(data.to_container(), net)
         if normalization:
             for line in data._lines:
                 line["text"] = normalize(normalization, line["text"])
-        im = Image.open(data.imagename).convert('RGBA')
+        im = open_image(data.imagename).convert('RGBA')
         result = align.forced_align(data.to_container(), net)
         if output == 'overlay':
             tmp = Image.new('RGBA', im.size, (0, 0, 0, 0))

--- a/kraken/contrib/heatmap_overlay.py
+++ b/kraken/contrib/heatmap_overlay.py
@@ -22,6 +22,7 @@ def cli(model, files):
     from PIL import Image
 
     from kraken.lib import dataset, vgsl
+    from kraken.lib.util import open_image
 
     model = vgsl.TorchVGSLModel.load_model(model)
     model.eval()
@@ -33,7 +34,7 @@ def cli(model, files):
 
     for img in files:
         print(img)
-        im = Image.open(img)
+        im = open_image(img)
         xs = transforms(im)
 
         with torch.no_grad():

--- a/kraken/contrib/print_word_spreader.py
+++ b/kraken/contrib/print_word_spreader.py
@@ -10,6 +10,8 @@ from statistics import mean
 from lxml import etree
 from PIL import Image
 
+from kraken.lib.util import open_image
+
 
 # a custom exception to indicate when a page or other element doesn't
 # have a bounding box where we would expect it.
@@ -215,7 +217,7 @@ def rewrite_ocr_page_title(xhtml, file_name, image_x, image_y):
     ocr_page = xhtml.xpath("//html:div[@class='ocr_page'][1]", namespaces={'html': "http://www.w3.org/1999/xhtml"})[0]
     image_file_name = (file_name.rsplit('.', 1)[0] + '.png')
     image_path = os.path.join(args.imageDir, image_file_name)
-    image = Image.open(image_path)
+    image = open_image(image_path)
     image_x, image_y = image.size
     new_title = "bbox 0 0 " + str(image_x) + " " + str(image_y) + ";image " + image_file_name
     ocr_page.set('title', new_title)
@@ -285,7 +287,7 @@ for root, dirs, files in os.walk(args.inputDir):
                                 # remove '.html' and add '.png'
                                 image_file_name = file_name[:-5] + '.png'
                                 image_path = os.path.join(args.imageDir, image_file_name)
-                                image = Image.open(image_path)
+                                image = open_image(image_path)
                                 image_x, image_y = image.size
                                 rewrite_ocr_page_title(xhtml, file_name, image_x, image_y)
                                 fix_word_span_area(xhtml)

--- a/kraken/contrib/recognition_boxes.py
+++ b/kraken/contrib/recognition_boxes.py
@@ -11,6 +11,7 @@ from itertools import cycle
 from PIL import Image, ImageDraw
 
 from kraken.binarization import nlbin
+from kraken.lib.util import open_image
 from kraken.lib import models
 from kraken.pageseg import segment
 from kraken.rpred import rpred
@@ -26,7 +27,7 @@ cmap = cycle([(230, 25, 75, 127),
 net = models.load_any(sys.argv[1])
 
 for fname in sys.argv[2:]:
-    im = Image.open(fname)
+    im = open_image(fname)
     print(fname)
     im = nlbin(im)
     res = segment(im, maxcolseps=0)

--- a/kraken/contrib/repolygonize.py
+++ b/kraken/contrib/repolygonize.py
@@ -34,9 +34,9 @@ def cli(format_type, topline, scale, files):
     from os.path import splitext
 
     from lxml import etree
-    from PIL import Image
 
     from kraken.lib import xml
+    from kraken.lib.util import open_image
     from kraken.lib.segmentation import calculate_polygonal_environment
 
     def _repl_alto(fname, polygons):
@@ -99,7 +99,7 @@ def cli(format_type, topline, scale, files):
     for doc in files:
         click.echo(f'Processing {doc} ')
         seg = xml.XMLPage(doc).to_container()
-        im = Image.open(seg.imagename).convert('L')
+        im = open_image(seg.imagename).convert('L')
         baselines = []
         for x in seg.lines:
             bl = x.baseline if x.baseline is not None else [0, 0]

--- a/kraken/contrib/segmentation_overlay.py
+++ b/kraken/contrib/segmentation_overlay.py
@@ -67,6 +67,7 @@ def cli(model, text_direction, repolygonize, topline, height_scale, files):
 
     from kraken import blla
     from kraken.lib import segmentation, vgsl, xml
+    from kraken.lib.util import open_image
 
     loc = {'topline': True,
            'baseline': False,
@@ -79,7 +80,7 @@ def cli(model, text_direction, repolygonize, topline, height_scale, files):
             click.echo(f'Processing {doc} ', nl=False)
             data = xml.XMLPage(doc).to_container()
             if repolygonize:
-                im = Image.open(data.imagename).convert('L')
+                im = open_image(data.imagename).convert('L')
                 lines = data.lines
                 polygons = segmentation.calculate_polygonal_environment(im,
                                                                         [x.baseline for x in lines],
@@ -90,7 +91,7 @@ def cli(model, text_direction, repolygonize, topline, height_scale, files):
             lines = defaultdict(list)
             for line in data.lines:
                 lines[line.tags['type'][0]['type']].append(line)
-            im = Image.open(data.imagename).convert('RGBA')
+            im = open_image(data.imagename).convert('RGBA')
             for t, ls in lines.items():
                 tmp = Image.new('RGBA', im.size, (0, 0, 0, 0))
                 draw = ImageDraw.Draw(tmp)
@@ -119,7 +120,7 @@ def cli(model, text_direction, repolygonize, topline, height_scale, files):
         net = vgsl.TorchVGSLModel.load_model(model)
         for doc in files:
             click.echo(f'Processing {doc} ', nl=False)
-            im = Image.open(doc)
+            im = open_image(doc)
             res = blla.segment(im, model=net, text_direction=text_direction)
             # reorder lines by type
             lines = defaultdict(list)

--- a/kraken/kraken.py
+++ b/kraken/kraken.py
@@ -72,7 +72,8 @@ def get_input_parser(type_str: str) -> Callable[[str], dict[str, Any]]:
         from kraken.lib.xml import XMLPage
         return XMLPage
     elif type_str == 'image':
-        return Image.open
+        from kraken.lib.util import open_image
+        return open_image
 
 
 # chainable functions of functional components (binarization/segmentation/recognition)
@@ -89,7 +90,8 @@ def binarizer(threshold, zoom, escale, border, perc, range, low, high, input, ou
         raise click.UsageError('Binarization has to be the initial process.')
 
     try:
-        im = Image.open(input)
+        from kraken.lib.util import open_image
+        im = open_image(input)
     except IOError as e:
         raise click.BadParameter(str(e))
     message('Binarizing\t', nl=False)
@@ -140,7 +142,8 @@ def segmenter(legacy, model, config, input, output) -> None:
         ctx.meta['base_image'] = input
 
     try:
-        im = Image.open(input)
+        from kraken.lib.util import open_image
+        im = open_image(input)
     except IOError as e:
         raise click.BadParameter(str(e))
     message(f'Segmenting {ctx.meta["orig_file"]}\t', nl=False)
@@ -206,7 +209,8 @@ def recognizer(model, no_segmentation, config, input, output) -> None:
                 config.bidi_reordering = doc.base_dir
             bounds = doc.to_container()
     try:
-        im = Image.open(ctx.meta['base_image'])
+        from kraken.lib.util import open_image
+        im = open_image(ctx.meta['base_image'])
     except IOError as e:
         raise click.BadParameter(str(e))
 
@@ -250,7 +254,7 @@ def recognizer(model, no_segmentation, config, input, output) -> None:
         if ctx.meta['output_mode'] != 'native':
             from kraken import serialization
             fp.write(serialization.serialize(results=results,
-                                             image_size=Image.open(ctx.meta['base_image']).size,
+                                             image_size=open_image(ctx.meta['base_image']).size,
                                              writing_mode=ctx.meta['text_direction'],
                                              scripts=None,
                                              template=ctx.meta['output_template'],

--- a/kraken/lib/arrow_dataset.py
+++ b/kraken/lib/arrow_dataset.py
@@ -33,7 +33,7 @@ from kraken.containers import Segmentation
 from kraken.lib import functional_im_transforms as F_t
 from kraken.lib.exceptions import KrakenInputException
 from kraken.lib.segmentation import extract_polygons
-from kraken.lib.util import is_bitonal, make_printable
+from kraken.lib.util import is_bitonal, make_printable, open_image
 from kraken.lib.xml import XMLPage
 
 if TYPE_CHECKING:
@@ -47,7 +47,7 @@ logger = logging.getLogger(__name__)
 def _extract_line(xml_record, skip_empty_lines: bool = True, legacy_polygons: bool = False):
     lines = []
     try:
-        im = Image.open(xml_record.imagename)
+        im = open_image(xml_record.imagename)
         if is_bitonal(im):
             im = im.convert('1')
     except (OSError, FileNotFoundError, UnidentifiedImageError) as err:
@@ -79,7 +79,7 @@ def _extract_line(xml_record, skip_empty_lines: bool = True, legacy_polygons: bo
 
 def _extract_path_line(xml_record, skip_empty_lines: bool = True):
     try:
-        im = Image.open(xml_record['image'])
+        im = open_image(xml_record['image'])
     except (FileNotFoundError, UnidentifiedImageError) as err:
         logger.warning(f'Error loading image {xml_record.imagename}: {err}')
         return [], None

--- a/kraken/lib/dataset/recognition.py
+++ b/kraken/lib/dataset/recognition.py
@@ -40,7 +40,7 @@ from kraken.lib import functional_im_transforms as F_t
 from kraken.lib.codec import PytorchCodec
 from kraken.lib.exceptions import KrakenEncodeException, KrakenInputException
 from kraken.lib.segmentation import extract_polygons
-from kraken.lib.util import is_bitonal
+from kraken.lib.util import is_bitonal, open_image
 
 if TYPE_CHECKING:
     from os import PathLike
@@ -447,7 +447,7 @@ class PolygonGTDataset(Dataset):
             logger.debug(f'Attempting to load {item[0]}')
             im = item[0][0]
             if not isinstance(im, Image.Image):
-                im = Image.open(im)
+                im = open_image(im)
             im, _ = next(extract_polygons(im,
                                           Segmentation(type='baselines',
                                                        imagename=item[0][0],
@@ -644,7 +644,7 @@ class GroundTruthDataset(Dataset):
             flat_box = [x for point in bbox for x in point]
             xmin, xmax = min(flat_box[::2]), max(flat_box[::2])
             ymin, ymax = min(flat_box[1::2]), max(flat_box[1::2])
-            im = Image.open(im)
+            im = open_image(im)
             im = im.crop((xmin, ymin, xmax, ymax))
             im = self.transforms(im)
             if im.shape[0] == 3:

--- a/kraken/lib/dataset/segmentation.py
+++ b/kraken/lib/dataset/segmentation.py
@@ -36,7 +36,7 @@ from torchvision.transforms import v2
 
 from kraken.lib.dataset.utils import _get_type
 from kraken.lib.segmentation import scale_regions
-from kraken.lib.util import is_bitonal
+from kraken.lib.util import is_bitonal, open_image
 
 if TYPE_CHECKING:
     from kraken.containers import Segmentation
@@ -224,7 +224,7 @@ class BaselineSet(Dataset):
         if not isinstance(im, Image.Image):
             try:
                 logger.debug(f'Attempting to load {im}')
-                im = Image.open(im)
+                im = open_image(im)
                 im, target, baselines = self.transform(im, target)
                 self._update_im_mode(im)
                 return {'image': im, 'target': target, 'baselines': baselines}

--- a/kraken/lib/util.py
+++ b/kraken/lib/util.py
@@ -17,7 +17,15 @@ from kraken.lib.exceptions import KrakenInputException
 if TYPE_CHECKING:
     from os import PathLike
 
-__all__ = ['pil2array', 'array2pil', 'is_bitonal', 'make_printable', 'get_im_str', 'parse_gt_path']
+__all__ = ['pil2array', 'array2pil', 'is_bitonal', 'make_printable', 'get_im_str', 'open_image', 'parse_gt_path']
+
+
+def open_image(fp) -> Image.Image:
+    """Opens an image and applies EXIF rotation if present."""
+    from PIL import ImageOps
+    im = Image.open(fp)
+    im = ImageOps.exif_transpose(im)
+    return im
 
 
 def pil2array(im: Image.Image, alpha: int = 0) -> np.ndarray:
@@ -125,7 +133,7 @@ def parse_gt_path(path: Union[str, 'PathLike'],
         text_direction: Orientation of the line box.
     """
     try:
-        with Image.open(path) as im:
+        with open_image(path) as im:
             w, h = im.size
     except Exception as e:
         raise KrakenInputException(e)

--- a/kraken/lib/xml/alto.py
+++ b/kraken/lib/xml/alto.py
@@ -112,8 +112,8 @@ def parse_alto(doc, filename, linetype):
     if not image_size[0] or not image_size[1]:
         logger.warning(f'Invalid image dimensions {image_size} in {filename}. Attempting to read from image file.')
         try:
-            from PIL import Image
-            with Image.open(imagename) as im:
+            from kraken.lib.util import open_image
+            with open_image(imagename) as im:
                 image_size = im.size
         except Exception as e:
             raise ValueError(f'Invalid image dimensions {image_size} in {filename} and unable to read image file {imagename}: {e}')

--- a/kraken/lib/xml/page.py
+++ b/kraken/lib/xml/page.py
@@ -90,8 +90,8 @@ def parse_page(doc, filename, linetype):
     if not image_size[0] or not image_size[1]:
         logger.warning(f'Invalid image dimensions {image_size} in {filename}. Attempting to read from image file.')
         try:
-            from PIL import Image
-            with Image.open(imagename) as im:
+            from kraken.lib.util import open_image
+            with open_image(imagename) as im:
                 image_size = im.size
         except Exception as e:
             raise ValueError(f'Invalid image dimensions {image_size} in {filename} and unable to read image file {imagename}: {e}')


### PR DESCRIPTION
PIL does not rotate images according to the EXIF metadata orientation value by default causing broken recognition and segmentation. This pull request wraps all `Image.open` calls on externally loaded images with a new helper function `open_image()` that runs the `ImageOps.exif_rotate()` function on them before returning the image object.