### PR TITLE
ci: add Windows to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,11 +5,15 @@ on:
 
 jobs:
   lint_and_test:
-    name: Runs the linter and tests
-    runs-on: ubuntu-latest
+    name: Runs the linter and tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest]
         python-version: ['3.10', '3.11', '3.12', '3.13']
+        include:
+          - os: windows-latest
+            python-version: '3.13'
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Add `windows-latest` with Python 3.13 to the CI test matrix alongside the existing `ubuntu-latest` runs.

## Changes

- Refactor CI job name to include OS from matrix
- Add `os` matrix variable with `ubuntu-latest` default
- Add `include` entry for `windows-latest` + Python 3.13

## Motivation

kraken now works on Windows (with `PYTHONUTF8=1` set). Adding Windows to CI ensures compatibility is tested automatically and prevents regressions.

## Testing

Verified locally on Windows 11 with Python 3.13.13.
