### PR TITLE
feat: platform-conditional PDF backend and case-insensitive model suffix

### DIFF
--- a/kraken/kraken.py
+++ b/kraken/kraken.py
@@ -362,42 +362,84 @@ def process_pipeline(subcommands, input, batch_input, suffix, verbose, format_ty
 
     # parse pdfs
     if format_type == 'pdf':
-        import pyvips
+        import sys as _sys
+        new_input = []
+        num_pages = 0
+
+        def _get_pdf_backend():
+            """Select PDF backend: pypdfium2 on Windows, pyvips elsewhere."""
+            if _sys.platform == 'win32':
+                try:
+                    import pypdfium2 as pdfium
+                    return 'pypdfium2', pdfium
+                except ImportError:
+                    pass
+            try:
+                import pyvips
+                return 'pyvips', pyvips
+            except ImportError:
+                pass
+            raise click.ClickException('No PDF backend available. '
+                                       'Install pypdfium2 (pip install kraken[pdf]) or pyvips.')
+
+        backend_name, backend = _get_pdf_backend()
 
         if not batch_input:
             logger.warning('PDF inputs not added with batch option. Manual output filename will be ignored and `-o` utilized.')
-        new_input = []
-        num_pages = 0
-        for (fpath, _) in input:
-            doc = pyvips.Image.new_from_file(fpath, dpi=300, n=-1, access="sequential")
-            if 'n-pages' in doc.get_fields():
-                num_pages += doc.get('n-pages')
+
+        if backend_name == 'pypdfium2':
+            for (fpath, _) in input:
+                pdf_doc = backend.PdfDocument(fpath)
+                num_pages += len(pdf_doc)
+                pdf_doc.close()
+        else:
+            for (fpath, _) in input:
+                doc = backend.Image.new_from_file(fpath, dpi=300, n=-1, access="sequential")
+                if 'n-pages' in doc.get_fields():
+                    num_pages += doc.get('n-pages')
 
         with KrakenProgressBar() as progress:
             pdf_parse_task = progress.add_task('Extracting PDF pages', total=num_pages, visible=True if not ctx.meta['verbose'] else False)
             for (fpath, _) in input:
                 try:
-                    doc = pyvips.Image.new_from_file(fpath, dpi=300, n=-1, access="sequential")
-                    if 'n-pages' not in doc.get_fields():
-                        logger.warning('{fpath} does not contain pages. Skipping.')
-                        continue
-                    n_pages = doc.get('n-pages')
+                    if backend_name == 'pypdfium2':
+                        pdf_doc = backend.PdfDocument(fpath)
+                        n_pages = len(pdf_doc)
+                        dest_dict = {'idx': -1, 'src': fpath, 'uuid': None}
+                        for i in range(n_pages):
+                            dest_dict['idx'] += 1
+                            dest_dict['uuid'] = f'_{uuid.uuid4()}'
+                            fd, filename = tempfile.mkstemp(suffix='.png')
+                            os.close(fd)
+                            page = pdf_doc[i]
+                            bitmap = page.render(scale=300/72)
+                            pil_image = bitmap.to_pil()
+                            pil_image.save(filename)
+                            new_input.append((filename, pdf_format.format(**dest_dict) + suffix))
+                            progress.update(pdf_parse_task, advance=1)
+                        pdf_doc.close()
+                    else:
+                        doc = backend.Image.new_from_file(fpath, dpi=300, n=-1, access="sequential")
+                        if 'n-pages' not in doc.get_fields():
+                            logger.warning('{fpath} does not contain pages. Skipping.')
+                            continue
+                        n_pages = doc.get('n-pages')
 
-                    dest_dict = {'idx': -1, 'src': fpath, 'uuid': None}
-                    for i in range(0, n_pages):
-                        dest_dict['idx'] += 1
-                        dest_dict['uuid'] = f'_{uuid.uuid4()}'
-                        fd, filename = tempfile.mkstemp(suffix='.png')
-                        os.close(fd)
-                        doc = pyvips.Image.new_from_file(fpath, dpi=300, page=i, access="sequential")
-                        logger.info(f'Saving temporary image {fpath}:{dest_dict["idx"]} to {filename}')
-                        doc.write_to_file(filename)
-                        new_input.append((filename, pdf_format.format(**dest_dict) + suffix))
-                        progress.update(pdf_parse_task, advance=1)
-                except pyvips.error.Error:
+                        dest_dict = {'idx': -1, 'src': fpath, 'uuid': None}
+                        for i in range(0, n_pages):
+                            dest_dict['idx'] += 1
+                            dest_dict['uuid'] = f'_{uuid.uuid4()}'
+                            fd, filename = tempfile.mkstemp(suffix='.png')
+                            os.close(fd)
+                            doc = backend.Image.new_from_file(fpath, dpi=300, page=i, access="sequential")
+                            logger.info(f'Saving temporary image {fpath}:{dest_dict["idx"]} to {filename}')
+                            doc.write_to_file(filename)
+                            new_input.append((filename, pdf_format.format(**dest_dict) + suffix))
+                            progress.update(pdf_parse_task, advance=1)
+                except Exception as e:
                     num_pages -= n_pages
                     progress.update(pdf_parse_task, total=num_pages)
-                    logger.warning(f'{fpath} is not a PDF file. Skipping.')
+                    logger.warning(f'{fpath} is not a PDF file. Skipping. ({e})')
         input = new_input
         ctx.meta['steps'].insert(0, ProcessingStep(id=f'_{uuid.uuid4()}',
                                                    category='preprocessing',
@@ -798,7 +840,7 @@ def get(ctx, model_id):
         download_task = progress.add_task('Processing', total=0, visible=True if not ctx.meta['verbose'] else False)
         model_dir = get_model(model_id,
                               callback=lambda total, advance: progress.update(download_task, total=total, advance=advance))
-    model_candidates = list(filter(lambda x: x.suffix in ['.mlmodel', '.safetensors'], model_dir.iterdir()))
+    model_candidates = list(filter(lambda x: x.suffix.lower() in ['.mlmodel', '.safetensors'], model_dir.iterdir()))
     message(f'Model dir: {model_dir} (model files: {", ".join(x.name for x in model_candidates)})')
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: POSIX",
+    "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -59,7 +60,10 @@ dependencies = [
 
 [project.optional-dependencies]
 test = ["hocr-spec", "pytest"]
-pdf = ["pyvips"]
+pdf = [
+    "pyvips; sys_platform != 'win32'",
+    "pypdfium2>=4; sys_platform == 'win32'",
+]
 docs = [
     "sphinx<9",
     "sphinx-autoapi",


### PR DESCRIPTION
## Summary

Add `pypdfium2` as the default PDF backend on Windows, keeping `pyvips` on Linux/macOS. Also fix case-insensitive model suffix matching for Windows filesystems.

## Changes

### PDF backend abstraction (`kraken/kraken.py`)
- New `_get_pdf_backend()` helper selects `pypdfium2` on `win32`, `pyvips` elsewhere
- Clear error message if no PDF backend is available
- pypdfium2 path: `PdfDocument()` -> `page.render(scale=300/72).to_pil().save()`
- pyvips path: unchanged (wrapped via `backend` variable)
- Exception handling widened from `pyvips.error.Error` to `Exception` for both backends

### Case-insensitive suffix (`kraken/kraken.py`)
- Changed `x.suffix in ['.mlmodel', '.safetensors']` to `x.suffix.lower() in [...]`
- On Windows, `Path('foo.MLMODEL').suffix` returns `.MLMODEL`, breaking the filter

### Platform-conditional extras (`pyproject.toml`)
```toml
pdf = [
    "pyvips; sys_platform != 'win32'",
    "pypdfium2>=4; sys_platform == 'win32'",
]
```

## Motivation

pyvips requires native `libvips` DLLs which are not readily available on Windows. pypdfium2 provides pure-Python wheels with native PDF rendering, making it the ideal Windows backend.

## Testing

- Verified `pypdfium2.PdfDocument` loads and renders PDF pages on Windows 11
- Verified case-insensitive suffix filter finds `.MLMODEL` files on Windows
