### PR TITLE
fix: add explicit UTF-8 encoding and symlink fallback for Windows

### DIFF
--- a/kraken/contrib/extract_lines.py
+++ b/kraken/contrib/extract_lines.py
@@ -42,7 +42,7 @@ def cli(format_type, model, legacy_polygons, files):
                     for idx, (im, box) in enumerate(segmentation.extract_polygons(open_image(bounds.imagename), bounds, legacy=legacy_polygons)):
                         click.echo('.', nl=False)
                         im.save('{}.{}.jpg'.format(splitext(bounds.imagename)[0], idx))
-                        with open('{}.{}.gt.txt'.format(splitext(bounds.imagename)[0], idx), 'w') as fp:
+                        with open('{}.{}.gt.txt'.format(splitext(bounds.imagename)[0], idx), 'w', encoding='utf-8') as fp:
                             fp.write(box.text)
             else:
                 with pa.memory_map(doc, 'rb') as source:
@@ -55,7 +55,7 @@ def cli(format_type, model, legacy_polygons, files):
                         sample = ds_table.column('lines')[idx].as_py()
                         im = Image.open(io.BytesIO(sample['im'])).convert('RGB')
                         im.save('{}.{}.jpg'.format(splitext(doc)[0], idx))
-                        with open('{}.{}.gt.txt'.format(splitext(doc)[0], idx), 'w') as fp:
+                        with open('{}.{}.gt.txt'.format(splitext(doc)[0], idx), 'w', encoding='utf-8') as fp:
                             fp.write(sample['text'])
             click.echo()
     else:

--- a/kraken/contrib/generate_scripts.py
+++ b/kraken/contrib/generate_scripts.py
@@ -11,7 +11,7 @@ uri = 'http://www.unicode.org/Public/UNIDATA/Scripts.txt'
 
 re = regex.compile(r'^(?P<start>[0-9A-F]{4,6})(..(?P<end>[0-9A-F]{4,6}))?\s+; (?P<name>[A-Za-z]+)')
 
-with open('scripts.json', 'w') as fp, request.urlopen(uri) as req:
+with open('scripts.json', 'w', encoding='utf-8') as fp, request.urlopen(uri) as req:
     d = []
     for line in req:
         line = line.decode('utf-8')

--- a/kraken/contrib/print_word_spreader.py
+++ b/kraken/contrib/print_word_spreader.py
@@ -263,7 +263,7 @@ for root, dirs, files in os.walk(args.inputDir):
     for file_name in files:
         if file_name.endswith(EXTENSIONS):
             print(file_name)
-            with open(os.path.join(args.inputDir, file_name)) as file:  # Use file to refer to the file
+            with open(os.path.join(args.inputDir, file_name), encoding='utf-8') as file:  # Use file to refer to the file
                 try:
                     tree = etree.parse(file)
                     find_xhtml_body = etree.ETXPath("//{%s}body" % XHTML_NAMESPACE)

--- a/kraken/contrib/set_seg_options.py
+++ b/kraken/contrib/set_seg_options.py
@@ -48,7 +48,7 @@ def cli(bounding_region, topline, pad, output_identifiers, output_format, model)
             print(f'  {k}\t{v}')
 
         if output_identifiers:
-            with open(output_identifiers, 'r') as fp:
+            with open(output_identifiers, 'r', encoding='utf-8') as fp:
                 new_cls_map = json.load(fp)
             print('-> Updating class maps')
             if 'baselines' in new_cls_map:

--- a/kraken/ketos/repo.py
+++ b/kraken/ketos/repo.py
@@ -19,6 +19,8 @@ kraken.ketos.repo
 Command line driver for publishing models to the model repository.
 """
 import re
+import json
+import shutil
 import logging
 
 import click
@@ -246,7 +248,10 @@ def publish(ctx, metadata, access_token, doi, private, model):
 
         model_path = model_path.resolve()
         tmpdir = Path(tmpdir)
-        (tmpdir / model_path.name).resolve().symlink_to(model_path)
+        try:
+            (tmpdir / model_path.name).resolve().symlink_to(model_path)
+        except OSError:
+            shutil.copy2(model_path, tmpdir / model_path.name)
         if rec_models:
             # v0 metadata only supports recognition models
             nn_rec = rec_models[0]
@@ -260,7 +265,7 @@ def publish(ctx, metadata, access_token, doi, private, model):
             }
             if frontmatter.get('metrics'):
                 v0_metadata['accuracy'] = 100 - frontmatter['metrics']['cer']
-            with open(tmpdir / 'metadata.json', 'w') as fo:
+            with open(tmpdir / 'metadata.json', 'w', encoding='utf-8') as fo:
                 json.dump(v0_metadata, fo)
         kwargs = {'model': tmpdir,
                   'model_card': f'---\n{yaml.dump(frontmatter)}---\n{content}',

--- a/kraken/serialization.py
+++ b/kraken/serialization.py
@@ -254,7 +254,7 @@ def serialize(results: 'Segmentation',
         loader = PackageLoader('kraken', 'templates')
     elif template_source == 'custom':
         def _load_template(name):
-            return open(template, 'r').read(), name, lambda: True
+            return open(template, 'r', encoding='utf-8').read(), name, lambda: True
         loader = FunctionLoader(_load_template)
 
     env = Environment(loader=loader,


### PR DESCRIPTION
## Summary

Add explicit `encoding='utf-8'` to all `open()` calls that read/write text files, and add a `shutil.copy2` fallback for symlink creation on Windows.

## Changes

### Explicit UTF-8 encoding
Added `encoding='utf-8'` to text file `open()` calls in:
- `kraken/serialization.py`: custom template loading
- `kraken/ketos/repo.py`: metadata.json writing
- `kraken/contrib/extract_lines.py`: ground truth text output (2 calls)
- `kraken/contrib/generate_scripts.py`: scripts.json output
- `kraken/contrib/print_word_spreader.py`: XML file reading
- `kraken/contrib/set_seg_options.py`: JSON identifier file reading

### Symlink fallback (`kraken/ketos/repo.py`)
- Try `Path.symlink_to()` first, fall back to `shutil.copy2()` on `OSError`
- Windows without Developer Mode or admin privileges cannot create symlinks
- Added `import shutil` and `import json` to repo.py

## Motivation

On Windows, `open()` without explicit encoding defaults to the system codepage (cp1252), which fails on UTF-8 content. This is a correctness improvement on all platforms, not just Windows.

Symlinks require elevated privileges on Windows. The fallback ensures `kraken publish` works in standard user environments.

## Testing

- Verified all modified files load correctly on Windows 11 with `PYTHONUTF8=1`
- Verified symlink fallback creates a regular file copy when symlinks are unavailable
