### PR TITLE
Fix validation_step crash when a TensorBoard logger is attached

### DIFF
--- a/kraken/train/vgsl.py
+++ b/kraken/train/vgsl.py
@@ -371,8 +371,10 @@ class VGSLRecognitionModel(KrakenTrainerModule):
         for offset in batch['target_lens']:
             targets.append(''.join([x[0] for x in self._val_codec.decode([(x, 0, 0, 0) for x in batch['target'][idx:idx + offset]])]))
             idx += offset
+        pred_strs = []
         for pred, target in zip([self.net.codec.decode(locs) for locs in RecognitionInferenceConfig().decoder(preds, olens)], targets):
             pred_str = ''.join(x[0] for x in pred)
+            pred_strs.append(pred_str)
             self.val_cer.update(pred_str, target)
             self.val_wer.update(pred_str, target)
 
@@ -380,7 +382,7 @@ class VGSLRecognitionModel(KrakenTrainerModule):
            self.trainer.state.stage != 'sanity_check' and \
            self.hparams.config.batch_size * batch_idx < 16 and \
            getattr(self.logger.experiment, 'add_image', None) is not None:
-            for i in range(self.hparams.config.batch_size):
+            for i in range(min(self.hparams.config.batch_size, len(targets))):
                 count = self.hparams.config.batch_size * batch_idx + i
                 if count < 16:
                     self.logger.experiment.add_image(f'Validation #{count}, target: {targets[i]}',
@@ -388,7 +390,7 @@ class VGSLRecognitionModel(KrakenTrainerModule):
                                                      self.global_step,
                                                      dataformats="CHW")
                     self.logger.experiment.add_text(f'Validation #{count}, target: {targets[i]}',
-                                                    pred[i],
+                                                    pred_strs[i],
                                                     self.global_step)
 
     def on_validation_epoch_end(self):


### PR DESCRIPTION
## Problem

`VGSLRecognitionModel.validation_step` crashes as soon as an experiment logger
whose backend exposes `add_image` (e.g. `TensorBoardLogger`) is attached:

```
File ".../kraken/train/vgsl.py", line 390, in validation_step
    self.logger.experiment.add_text(f'Validation #{count}, target: {targets[i]}',
File ".../torch/utils/tensorboard/writer.py", line 826, in add_text
File ".../torch/utils/tensorboard/summary.py", line 798, in text
    string_val=[text.encode(encoding="utf_8")],
AttributeError: 'tuple' object has no attribute 'encode'
```

The per-sample preview passes `pred[i]` to `add_text` instead of `pred_strs[i]`.

Because the block is gated on `getattr(self.logger.experiment, 'add_image', None)`,
it stays dormant with no logger / a logger lacking `add_image`, which is why it can
go unnoticed.

There is also a latent `IndexError`: the preview loops `range(batch_size)` and
indexes `targets[i]` / `batch['image'][i]`, which is out of range when a validation
batch is smaller than `batch_size` (e.g. the final batch, or a small val set).

## Repro

Train a recognition model with a TensorBoard logger attached, e.g.
`KrakenTrainer(pl_logger="tensorboard", log_dir=...)` (or `ketos train --logger
tensorboard` with `tensorboard` installed); it crashes at the first validation
step. Affects 7.0.2 and current `main`.
