### PR TITLE
Update requirement for htrmopo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "scikit-image~=0.25.2",
     "shapely~=2.1.2",
     "pyarrow",
-    "htrmopo>=0.5,~=0.5",
+    "htrmopo>=0.6,~=0.6",
     "lightning==2.6.1",
     "torchmetrics>=1.1.0",
     "threadpoolctl~=3.6.0",


### PR DESCRIPTION
PP-OCRv6 cannot be installed with release 0.5.