### PR TITLE
Fix CPU/CUDA tensor mismatch in PPOCR inference

### DIFF
--- a/kraken/lib/ppocr/network.py
+++ b/kraken/lib/ppocr/network.py
@@ -71,7 +71,7 @@ def _lengths_and_mask(seq_lens, w_in, w_out, device):
     Runs eagerly (``torch.compiler.disable``) to keep the ``w_out / w_in`` ratio
     out of the compile trace, which otherwise spams value-range warnings.
     """
-    scaled = (seq_lens.to(torch.float32) * (w_out / float(w_in))).floor().long()
+    scaled = (seq_lens.to(device=device, dtype=torch.float32) * (w_out / float(w_in))).floor().long()
     out_lens = scaled.clamp(min=1, max=w_out)
     positions = torch.arange(w_out, device=device)
     mask = positions[None, :] < out_lens[:, None]


### PR DESCRIPTION
Some invocations of kraken involving PPOCR inference on the gpu failed with:

`Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!`

The issue was that `seq_lens` wasn't being moved to the gpu. I've added the `device` argument to the conversion call, and now I don't get the error anymore.

This fix was found by ChatGPT. I'm submitting it because it's a one-line change and fixes the issue for me, but I'm not familiar with how Kraken normally handles CPU/GPU tensor movement, so I'm not sure whether this is the right approach.