### PR TITLE
Fix all whitespace warnings and errors reported by Pyflakes

### DIFF
--- a/kraken/lib/ppocr/__init__.py
+++ b/kraken/lib/ppocr/__init__.py
@@ -20,7 +20,7 @@ PP-OCRv6 text recognition models.
 """
 from .model import PPOCRv6Model
 from .network import (MODEL_VARIANTS, PPOCRv6Recognizer, PPOCRv6Variant,
-                     build_recognizer)
+                      build_recognizer)
 
 __all__ = ['MODEL_VARIANTS', 'PPOCRv6Model', 'PPOCRv6Recognizer',
            'PPOCRv6Variant', 'build_recognizer']

--- a/kraken/models/loaders.py
+++ b/kraken/models/loaders.py
@@ -123,7 +123,7 @@ def load_safetensors(path: Union[str, PathLike], tasks: Optional[Sequence[_T_tas
                 raise ValueError(f'No model metadata found in {path}.')
     except SafetensorError as e:
         raise ValueError(f'Invalid safetensors file {path}: {e}') from e
-    
+
     state_dict = load_file(path)
     tied_groups: dict = {}
     for name, t in models.state_dict().items():

--- a/kraken/train/utils.py
+++ b/kraken/train/utils.py
@@ -133,8 +133,8 @@ class KrakenTrainer(L.Trainer):
             elif pl_logger == 'wandb':
                 logger.debug('Creating wandb experiment logger')
                 kwargs['logger'] = L.pytorch.loggers.WandbLogger(project='kraken',
-                                                                  save_dir=log_dir,
-                                                                  log_model=False)
+                                                                 save_dir=log_dir,
+                                                                 log_model=False)
             else:
                 logger.error('`pl_logger` was set, but %s is not an accepted value', pl_logger)
                 raise ValueError(f'{pl_logger} is not acceptable as logger')

--- a/kraken/train/vgsl.py
+++ b/kraken/train/vgsl.py
@@ -421,7 +421,7 @@ class VGSLRecognitionModel(KrakenTrainerModule):
         self._pred_transforms: list[Callable[[str], str]] = []
         if data_config.normalization:
             self._pred_transforms.append(partial(F_t.text_normalize,
-                                                  normalization=data_config.normalization))
+                                                 normalization=data_config.normalization))
         if data_config.normalize_whitespace:
             self._pred_transforms.append(F_t.text_whitespace_normalize)
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -23,10 +23,10 @@ WORDS = ['kraken', 'paddle', 'ocrv6', 'recognition', 'model', 'text', 'line',
 # arabic_*_records.json), with combining characters as explicit escapes
 # (maddah above U+0653, hamza above U+0654)
 ARABIC_LINE_LOGICAL = ('\u0639\u0646\u062f \u0639\u062f\u0645 \u0627\u0644\u0639\u0635\u0628\u0627\u062a '
-                    '\u0627\u0630\u0627 \u0644\u0645 \u064a\u0643\u0646 \u0644\u0644\u0635\u063a\u064a\u0631\u0629 '
-                    '\u0627\u0654\u0645 \u0627\u0654\u064a\u0636\u0627\u064b \u0644\u0645\u0627\u0630 '
-                    '\u0643\u0631. . \u0648\u0644\u0646\u0627 \u0627\u0654\u0646 \u0646\u0642\u0648\u0644 '
-                    '\u0627\u0646 \u0627\u0644\u0627\u0653\u0645')
+                       '\u0627\u0630\u0627 \u0644\u0645 \u064a\u0643\u0646 \u0644\u0644\u0635\u063a\u064a\u0631\u0629 '
+                       '\u0627\u0654\u0645 \u0627\u0654\u064a\u0636\u0627\u064b \u0644\u0645\u0627\u0630 '
+                       '\u0643\u0631. . \u0648\u0644\u0646\u0627 \u0627\u0654\u0646 \u0646\u0642\u0648\u0644 '
+                       '\u0627\u0646 \u0627\u0644\u0627\u0653\u0645')
 
 
 def render_line(text, path, height=48):

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -310,4 +310,3 @@ class TestSegmentationCasts(unittest.TestCase):
         out = seg.to_bbox()
         self.assertEqual(out.type, 'bbox')
         self.assertEqual(out.lines, [])
-


### PR DESCRIPTION
This fixes 10 flake8 reports:

    3  E127 continuation line over-indented for visual indent
    5  E128 continuation line under-indented for visual indent
    1  W293 blank line contains whitespace
    1  W391 blank line at end of file