### PR TITLE
Support Python 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
-
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - uses: actions/checkout@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "OCR/HTR engine for all the languages"
 readme = {file = "README.rst", content-type = "text/x-rst"}
 license = "Apache-2.0"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10,<3.15"
 authors = [
     {name = "Benjamin Kiessling", email = "mittagessen@l.unchti.me"},
 ]
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: Image Recognition",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
@@ -32,17 +33,17 @@ dependencies = [
     "lxml",
     "requests",
     "click>=8.1,<8.3",
-    "numpy",
+    "numpy<2.5",
     "Pillow>=9.2.0",
     "regex",
-    "scipy~=1.15.3",
+    "scipy>=1.15.3,<1.17",
     "protobuf>=3.0.0",
     "coremltools~=9.0",
     "jinja2~=3.1.6",
     "torchvision>=0.5.0",
     "torch>=2.9.0,<=2.14",
     "scikit-learn~=1.7.2",
-    "scikit-image~=0.25.2",
+    "scikit-image>=0.25.2,<0.27",
     "shapely~=2.1.2",
     "pyarrow",
     "htrmopo>=0.6,~=0.6",


### PR DESCRIPTION
Raise the requires-python bound to <3.15 and allow scipy 1.16, which is the first series shipping cp314 wheels.

Allow also scikit-image 0.26 to get cp314 wheels.

Limit numpy to < 2.5 to avoid CI failures

Add also Python 3.14 to the test matrix.