### PR TITLE
Bump lightning from 2.6.1 to 2.6.5 in the pip group across 1 directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "shapely~=2.1.2",
     "pyarrow",
     "htrmopo>=0.6,~=0.6",
-    "lightning==2.6.1",
+    "lightning==2.6.5",
     "torchmetrics>=1.1.0",
     "threadpoolctl~=3.6.0",
     "platformdirs",


### PR DESCRIPTION
Bumps the pip group with 1 update in the / directory: [lightning](https://github.com/Lightning-AI/pytorch-lightning).


Updates `lightning` from 2.6.1 to 2.6.5
- [Release notes](https://github.com/Lightning-AI/pytorch-lightning/releases)
- [Commits](https://github.com/Lightning-AI/pytorch-lightning/compare/2.6.1...2.6.5)

---
updated-dependencies:
- dependency-name: lightning dependency-version: 2.6.5 dependency-type: direct:production ...